### PR TITLE
Enhance item filtering by attributes

### DIFF
--- a/my-app/src/Optimizer.tsx
+++ b/my-app/src/Optimizer.tsx
@@ -81,8 +81,13 @@ export default function Optimizer() {
       setError('Equipped items cost exceeds total cash');
       return;
     }
+    const attrSet = new Set(weights.map(w => w.type).filter(Boolean));
     const candidate = data.filter(
-      it => (!it.character || it.character === hero) && !equipped.includes(it.id ?? '')
+      it => (
+        (!it.character || it.character === hero) &&
+        !equipped.includes(it.id ?? '') &&
+        (attrSet.size === 0 || it.attributes.some(a => attrSet.has(a.type)))
+      )
     );
     const needed = toBuy;
     if (needed === 0) {
@@ -181,7 +186,7 @@ export default function Optimizer() {
           onSubmit={onCalculate}
           validate={validate}
         />
-        <ResultsSection eqItems={eqItems} eqCost={eqCost} cash={cash} results={results} alternatives={alternatives} />
+        <ResultsSection eqItems={eqItems} eqCost={eqCost} cash={cash} results={results} alternatives={alternatives} hero={hero} heroes={heroes} />
       </div>
     </div>
   );

--- a/my-app/src/components/Dropdown.tsx
+++ b/my-app/src/components/Dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 
 interface DropdownOption {
   value: string;

--- a/my-app/src/components/InputSection.tsx
+++ b/my-app/src/components/InputSection.tsx
@@ -1,8 +1,8 @@
 import type { Item, WeightRow } from '../types';
 import { rarityColor } from '../utils/optimizer';
+import { relevantAttributes } from '../utils/attributes';
 import Dropdown from './Dropdown';
 import NumberInput from './NumberInput';
-import React from 'react';
 
 interface Props {
   heroes: string[];
@@ -99,11 +99,17 @@ export default function InputSection({
                 { value: '', label: 'None' },
                 ...filteredItems
                   .sort((a, b) => a.cost - b.cost)
-                  .map((it) => ({
-                    value: it.id || it.name,
-                    label: `${it.name} (${it.cost}) ${it.attributes.filter(a => a.type !== 'description').map(a => `${a.type}-${a.value}`).join(', ')}`,
-                    color: rarityColor(it.rarity),
-                  })),
+                  .map((it) => {
+                    const attrs = relevantAttributes(it, hero, heroes)
+                      .filter(a => a.type !== 'description')
+                      .map(a => `${a.type}-${a.value}`)
+                      .join(', ');
+                    return {
+                      value: it.id || it.name,
+                      label: `${it.name} (${it.cost}) ${attrs}`,
+                      color: rarityColor(it.rarity),
+                    };
+                  }),
               ]}
               value={id}
               onChange={(value) => onEquippedChange(idx, value)}

--- a/my-app/src/components/NumberInput.tsx
+++ b/my-app/src/components/NumberInput.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 interface NumberInputProps {
   value: number;

--- a/my-app/src/components/ResultsSection.tsx
+++ b/my-app/src/components/ResultsSection.tsx
@@ -1,5 +1,6 @@
 import type { Item, ResultCombo } from '../types';
 import { rarityColor } from '../utils/optimizer';
+import { relevantAttributes } from '../utils/attributes';
 
 interface Props {
   eqItems: Item[];
@@ -7,9 +8,11 @@ interface Props {
   cash: number;
   results: ResultCombo | null;
   alternatives: ResultCombo[];
+  hero: string;
+  heroes: string[];
 }
 
-export default function ResultsSection({ eqItems, eqCost, cash, results, alternatives }: Props) {
+export default function ResultsSection({ eqItems, eqCost, cash, results, alternatives, hero, heroes }: Props) {
   return (
     <div className="space-y-6 bg-white rounded-xl shadow-lg p-6 sm:p-8">
       <h2 className="text-2xl font-bold text-gray-900 sm:text-3xl">Results</h2>
@@ -58,7 +61,7 @@ export default function ResultsSection({ eqItems, eqCost, cash, results, alterna
                     </span>
                   </div>
                   <ul className="mt-2 text-xs text-gray-600 space-y-1">
-                    {it.attributes.map((a, idx) => (
+                    {relevantAttributes(it, hero, heroes).map((a, idx) => (
                       <li key={idx} className="flex items-center">
                         <svg className="h-3 w-3 mr-1.5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />

--- a/my-app/src/utils/attributes.ts
+++ b/my-app/src/utils/attributes.ts
@@ -1,0 +1,11 @@
+import type { Item, Attribute } from '../types';
+
+/**
+ * Filter attributes to hide hero specific ones not matching the current hero.
+ * @param item The item containing attributes.
+ * @param hero Currently selected hero.
+ * @param heroes List of all hero names.
+ */
+export function relevantAttributes(item: Item, hero: string, heroes: string[]): Attribute[] {
+  return item.attributes.filter(a => !heroes.includes(a.type) || a.type === hero);
+}


### PR DESCRIPTION
## Summary
- prevent unused React imports in components
- filter optimization candidates so all purchased items contain at least one chosen attribute
- hide hero-specific attributes from dropdown and results using a helper
- pass hero information to `ResultsSection`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684560c7155c832baeba3169a270b6b0