### PR TITLE
Limit purchase candidates to selected attributes

### DIFF
--- a/my-app/src/Optimizer.tsx
+++ b/my-app/src/Optimizer.tsx
@@ -81,8 +81,12 @@ export default function Optimizer() {
       setError('Equipped items cost exceeds total cash');
       return;
     }
+    const selectedAttrs = new Set(weights.map(w => w.type));
     const candidate = data.filter(
-      it => (!it.character || it.character === hero) && !equipped.includes(it.id ?? '')
+      it =>
+        (!it.character || it.character === hero) &&
+        !equipped.includes(it.id ?? '') &&
+        it.attributes.some(a => selectedAttrs.has(a.type))
     );
     const needed = toBuy;
     if (needed === 0) {
@@ -100,19 +104,16 @@ export default function Optimizer() {
     let bestCombos: ResultCombo[] = [];
     const n = itemScores.length;
     function dfs(start: number, selected: Item[], cost: number, score: number) {
-      if (selected.length === needed) {
-        if (score > bestScore || (score === bestScore && cost < bestCost)) {
-          bestScore = score;
-          bestCost = cost;
-          bestCombos = [{ items: [...selected], cost, score }];
-        } else if (score === bestScore && cost >= bestCost) {
-          bestCombos.push({ items: [...selected], cost, score });
-        }
-        return;
+      if (score > bestScore || (score === bestScore && cost < bestCost)) {
+        bestScore = score;
+        bestCost = cost;
+        bestCombos = [{ items: [...selected], cost, score }];
+      } else if (score === bestScore && cost >= bestCost) {
+        bestCombos.push({ items: [...selected], cost, score });
       }
-      if (start >= n) return;
+      if (selected.length === needed || start >= n) return;
       const remaining = needed - selected.length;
-      const possible = score + (prefix[start + remaining] - prefix[start]);
+      const possible = score + (prefix[Math.min(n, start + remaining)] - prefix[start]);
       if (possible < bestScore) return;
       for (let i = start; i < n; i++) {
         const info = itemScores[i];

--- a/my-app/src/components/Dropdown.tsx
+++ b/my-app/src/components/Dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 
 interface DropdownOption {
   value: string;

--- a/my-app/src/components/InputSection.tsx
+++ b/my-app/src/components/InputSection.tsx
@@ -2,7 +2,6 @@ import type { Item, WeightRow } from '../types';
 import { rarityColor } from '../utils/optimizer';
 import Dropdown from './Dropdown';
 import NumberInput from './NumberInput';
-import React from 'react';
 
 interface Props {
   heroes: string[];

--- a/my-app/src/components/NumberInput.tsx
+++ b/my-app/src/components/NumberInput.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 interface NumberInputProps {
   value: number;


### PR DESCRIPTION
## Summary
- filter candidate items to only those that contain attributes selected for scoring
- allow optimizer to select fewer than the requested number of items by evaluating all partial combinations
- clean up unused React imports

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846046df420832b9623af7c0417de8e