### PR TITLE
Add item override support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Overwatch Tool
+
+This tool calculates optimal item builds. A new `overrides.json` file under `my-app/src` allows customizing item attributes. The JSON maps item names to replacement attribute arrays. Any matching item will use the provided attributes during calculation.

--- a/my-app/src/Optimizer.tsx
+++ b/my-app/src/Optimizer.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
-import type { Item, ResultCombo, RootData, WeightRow } from './types';
+import type { Item, ResultCombo, RootData, WeightRow, ItemOverride } from './types';
 import InputSection from './components/InputSection';
 import ResultsSection from './components/ResultsSection';
 import { aggregate, scoreFromMap } from './utils/optimizer';
 import rawData from './data.json?raw';
+import overridesRaw from './overrides.json?raw';
 
 export default function Optimizer() {
   const [data, setData] = useState<Item[]>([]);
@@ -22,9 +23,17 @@ export default function Optimizer() {
 
   useEffect(() => {
     const root: RootData = JSON.parse(rawData);
+    const overrides: Record<string, ItemOverride> = overridesRaw
+      ? JSON.parse(overridesRaw)
+      : {};
     const items: Item[] = [];
     const add = (tab: string, rarity: 'common' | 'rare' | 'epic', arr: Item[]) => {
-      arr.forEach(it => items.push({ ...it, tab, rarity }));
+      arr.forEach(it => {
+        const override = overrides[it.name];
+        const item = { ...it, tab, rarity };
+        if (override?.attributes) item.attributes = override.attributes;
+        items.push(item);
+      });
     };
     (['weapon', 'ability', 'survival'] as const).forEach(tab => {
       const rar = root.tabs[tab];

--- a/my-app/src/overrides.json
+++ b/my-app/src/overrides.json
@@ -1,0 +1,7 @@
+{
+  "Vampiric Blades": {
+    "attributes": [
+      { "type": "WP", "value": "20" }
+    ]
+  }
+}

--- a/my-app/src/overrides.json
+++ b/my-app/src/overrides.json
@@ -1,7 +1,61 @@
 {
-  "Vampiric Blades": {
+  "IRONSIGHTS": {
     "attributes": [
-      { "type": "WP", "value": "20" }
+      {
+        "type": "AS",
+        "value": "10%"
+      },
+      {
+        "type": "WP",
+        "value": "17%"
+      },
+      {
+        "type": "Editor's Note",
+        "value": "On average, you are about 30m away from your taget, giving you somewhere between a 10-20% weapon power bonus. 17% is a fair estimate."
+      }
+    ]
+  },
+  "TRIPOD": {
+    "attributes": [
+      {
+        "type": "WP",
+        "value": "13%"
+      },
+      {
+        "type": "Editor's Note",
+        "value": "You gain 10% weapon power when above. With the base 5%, estimate 8% gain, a total of 13% WP."
+      }
+    ]
+  },
+  "INFRARED LENSES": {
+    "attributes": [
+      {
+        "type": "AP",
+        "value": "25%"
+      },
+      {
+        "type": "WP",
+        "value": "5%"
+      },
+      {
+        "Editor's Note": "Item itself provides 15AP. Since dynamite and power-based effect also triggers burning, while themself don't trigger burning damage bonus, we estimate +10AP and +5WP that benefits from burning damage bonus."
+      }
+    ]
+  },
+  "FIRESTARTER": {
+    "attributes": [
+      {
+        "type": "Health",
+        "value": "50"
+      },
+      {
+        "type": "ALS",
+        "value": "30%"
+      },
+      {
+        "type": "Editor's Note",
+        "value": "Only life steal from burning damage, so estimate 5% ALS is missing from Bob and coach gun"
+      }
     ]
   }
 }

--- a/my-app/src/types.ts
+++ b/my-app/src/types.ts
@@ -33,6 +33,10 @@ export interface WeightRow {
   weight: number;
 }
 
+export interface ItemOverride {
+  attributes?: Attribute[];
+}
+
 export interface ResultCombo {
   items: Item[];
   cost: number;


### PR DESCRIPTION
## Summary
- allow overriding item attributes via `overrides.json`
- document override file

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68463a969e40832bb3e464f982e3a5ab