### PR TITLE
Add undo history dropdown

### DIFF
--- a/my-app/src/components/HistoryDropdown.tsx
+++ b/my-app/src/components/HistoryDropdown.tsx
@@ -1,0 +1,62 @@
+import { useState, useEffect, useRef } from 'react';
+import type { InputState } from '../slices/inputSlice';
+
+interface Props {
+  history: InputState[];
+}
+
+function summary(s: InputState) {
+  return `${s.hero} - $${s.cash}`;
+}
+
+export default function HistoryDropdown({ history }: Props) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen(v => !v)}
+        className="flex items-center gap-1 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+      >
+        History
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth="1.5"
+          stroke="currentColor"
+          className="size-4"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+        </svg>
+      </button>
+      {open && (
+        <div className="absolute z-10 mt-2 w-48 max-h-40 overflow-y-auto rounded border border-gray-300 bg-white text-sm shadow-lg">
+          {history.length > 0 ? (
+            <ul>
+              {history.map((h, idx) => (
+                <li key={idx} className="border-b px-3 py-2 last:border-none">
+                  {summary(h)}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="p-3 text-gray-500">No history</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/my-app/src/components/Toolbar.tsx
+++ b/my-app/src/components/Toolbar.tsx
@@ -1,9 +1,12 @@
 import { useEffect } from 'react';
 import { ActionCreators } from 'redux-undo';
-import { useAppDispatch } from '../hooks';
+import { useAppDispatch, useAppSelector } from '../hooks';
+import HistoryDropdown from './HistoryDropdown';
 
 export default function Toolbar() {
   const dispatch = useAppDispatch();
+  const past = useAppSelector(s => s.input.past);
+  const future = useAppSelector(s => s.input.future);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -18,21 +21,26 @@ export default function Toolbar() {
   }, [dispatch]);
 
   return (
-    <div className="flex gap-2 mb-4">
-      <button
-        type="button"
-        onClick={() => dispatch(ActionCreators.undo())}
-        className="rounded bg-gray-200 px-3 py-1 text-sm font-medium text-gray-700 hover:bg-gray-300"
-      >
-        Undo
-      </button>
-      <button
-        type="button"
-        onClick={() => dispatch(ActionCreators.redo())}
-        className="rounded bg-gray-200 px-3 py-1 text-sm font-medium text-gray-700 hover:bg-gray-300"
-      >
-        Redo
-      </button>
+    <div className="mb-6 flex items-center justify-between gap-4">
+      <div className="flex gap-2">
+        <button
+          type="button"
+          disabled={past.length === 0}
+          onClick={() => dispatch(ActionCreators.undo())}
+          className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-indigo-700 disabled:bg-gray-400"
+        >
+          Undo
+        </button>
+        <button
+          type="button"
+          disabled={future.length === 0}
+          onClick={() => dispatch(ActionCreators.redo())}
+          className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-indigo-700 disabled:bg-gray-400"
+        >
+          Redo
+        </button>
+      </div>
+      <HistoryDropdown history={past} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show undo history in a dropdown
- improve the toolbar styling
- disable undo/redo buttons when no action is available

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68480ac52414832b9556a77c81cf3953