### PR TITLE
Sort equipment by rarity and name

### DIFF
--- a/my-app/src/components/input/AvoidSection.tsx
+++ b/my-app/src/components/input/AvoidSection.tsx
@@ -4,6 +4,7 @@ import { useAppDispatch, useAppSelector } from '../../hooks';
 import { addAvoid, removeAvoid } from '../../slices/inputSlice';
 import type { Item } from '../../types';
 import { rarityColor } from '../../utils/optimizer';
+import { sortItemsByRarityAndName } from '../../utils/item';
 
 interface Props {
   items: Item[];
@@ -23,7 +24,7 @@ export default function AvoidSection({ items }: Props) {
           placeholder="Select item"
           options={[
             { value: '', label: 'Select item' },
-            ...items.sort((a, b) => a.cost - b.cost).map(it => ({
+            ...items.sort(sortItemsByRarityAndName).map(it => ({
               value: it.id || it.name,
               label: `${it.name} (${it.cost})`,
               color: rarityColor(it.rarity),

--- a/my-app/src/components/input/EquippedSection.tsx
+++ b/my-app/src/components/input/EquippedSection.tsx
@@ -5,6 +5,7 @@ import { setEquipped } from '../../slices/inputSlice';
 import type { Item } from '../../types';
 import { rarityColor } from '../../utils/optimizer';
 import { attributeValueToLabel } from '../../utils/attribute';
+import { sortItemsByRarityAndName } from '../../utils/item';
 
 interface Props {
   items: Item[];
@@ -47,7 +48,7 @@ export default function EquippedSection({ items }: Props) {
               options={[
                 { value: '', label: 'None' },
                 ...items
-                  .sort((a, b) => a.cost - b.cost)
+                  .sort(sortItemsByRarityAndName)
                   .map(it => ({
                     value: it.id || it.name,
                     label: `${it.name} (${it.cost}) ${it.attributes

--- a/my-app/src/utils/__tests__/itemSort.test.ts
+++ b/my-app/src/utils/__tests__/itemSort.test.ts
@@ -1,0 +1,17 @@
+import { sortItemsByRarityAndName } from '../item';
+
+interface Item { name: string; rarity: 'common' | 'rare' | 'epic'; }
+
+describe('sortItemsByRarityAndName', () => {
+  test('sorts by rarity then name', () => {
+    const items: Item[] = [
+      { name: 'Zeta', rarity: 'rare' },
+      { name: 'Alpha', rarity: 'common' },
+      { name: 'Beta', rarity: 'common' },
+      { name: 'Gamma', rarity: 'epic' },
+    ];
+    const sorted = [...items].sort(sortItemsByRarityAndName);
+    expect(sorted.map(i => i.name)).toEqual(['Alpha', 'Beta', 'Zeta', 'Gamma']);
+  });
+});
+

--- a/my-app/src/utils/item.ts
+++ b/my-app/src/utils/item.ts
@@ -1,0 +1,11 @@
+export function sortItemsByRarityAndName<ItemType extends { rarity: 'common' | 'rare' | 'epic'; name: string }>(a: ItemType, b: ItemType) {
+  const order: Record<'common' | 'rare' | 'epic', number> = {
+    common: 0,
+    rare: 1,
+    epic: 2
+  };
+  const diff = order[a.rarity] - order[b.rarity];
+  if (diff !== 0) return diff;
+  return a.name.localeCompare(b.name);
+}
+


### PR DESCRIPTION
## Summary
- add utility to sort items by rarity then alphabetically
- apply sorting in Equipped and Avoid dropdowns
- test new sort helper

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68480b37f848832bb7ac2e8abbb06635