### PR TITLE
Add damage breakpoint calculator

### DIFF
--- a/my-app/src/Optimizer.tsx
+++ b/my-app/src/Optimizer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import type { Item, ResultCombo, RootData, ItemOverride } from './types';
 import InputSection from './components/InputSection';
 import ResultsSection from './components/ResultsSection';
+import BreakPointCalculator from './components/BreakPointCalculator';
 import { aggregate, scoreFromMap } from './utils/optimizer';
 import rawData from './data.json?raw';
 import overridesRaw from './overrides.json?raw';
@@ -174,7 +175,7 @@ export default function Optimizer() {
   const eqCost = eqItems.reduce((s, it) => s + it.cost, 0);
 
   return (
-    <div className="bg-gray-50 min-h-screen p-4 sm:p-6 lg:p-8">
+    <div className="bg-gray-50 min-h-screen p-4 sm:p-6 lg:p-8 space-y-8">
       <div className="max-w-7xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-8">
         <InputSection
           heroes={heroes}
@@ -184,6 +185,9 @@ export default function Optimizer() {
           validate={validate}
         />
         <ResultsSection eqItems={eqItems} eqCost={eqCost} cash={cash} results={results} alternatives={alternatives} />
+      </div>
+      <div className="max-w-7xl mx-auto">
+        <BreakPointCalculator />
       </div>
     </div>
   );

--- a/my-app/src/components/BreakPointCalculator.tsx
+++ b/my-app/src/components/BreakPointCalculator.tsx
@@ -15,10 +15,11 @@ export default function BreakPointCalculator() {
     setRows(calculateBreakpoints(damage, bullets, hp, armor, penetrate))
   }
 
-  const maxShots = Math.max(...rows.map(r => r.shots), 1)
-  const points = rows
-    .map((r, idx) => {
-      const x = (idx / (rows.length - 1)) * 100
+  const finiteRows = rows.filter(r => Number.isFinite(r.shots))
+  const maxShots = Math.max(...finiteRows.map(r => r.shots), 1)
+  const points = finiteRows
+    .map(r => {
+      const x = r.percent
       const y = 100 - (r.shots / maxShots) * 100
       return `${x},${y}`
     })

--- a/my-app/src/components/BreakPointCalculator.tsx
+++ b/my-app/src/components/BreakPointCalculator.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react'
+
+import { calculateBreakpoints } from '../utils/breakpoint'
+import type { BreakPointResult } from '../utils/breakpoint'
+
+export default function BreakPointCalculator() {
+  const [collapsed, setCollapsed] = useState(true)
+  const [damage, setDamage] = useState(10)
+  const [bullets, setBullets] = useState(1)
+  const [hp, setHp] = useState(100)
+  const [armor, setArmor] = useState(0)
+  const [penetrate, setPenetrate] = useState(false)
+  const [rows, setRows] = useState<BreakPointResult[]>([])
+  const onCalc = () => {
+    setRows(calculateBreakpoints(damage, bullets, hp, armor, penetrate))
+  }
+
+  const maxShots = Math.max(...rows.map(r => r.shots), 1)
+  const points = rows
+    .map((r, idx) => {
+      const x = (idx / (rows.length - 1)) * 100
+      const y = 100 - (r.shots / maxShots) * 100
+      return `${x},${y}`
+    })
+    .join(' ')
+
+  return (
+    <div className="bg-white rounded-xl shadow-lg">
+      <button
+        className="w-full text-left p-4 font-bold text-xl border-b"
+        onClick={() => setCollapsed(!collapsed)}
+      >
+        Break Point Damage Calculator
+      </button>
+      {!collapsed && (
+        <div className="p-4 space-y-4">
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+            <label className="space-y-1">
+              <span className="block text-sm">Damage per Bullet</span>
+              <input type="number" value={damage} onChange={e => setDamage(Number(e.target.value))} className="w-full border rounded p-1" />
+            </label>
+            <label className="space-y-1">
+              <span className="block text-sm">Bullets per Shot</span>
+              <input type="number" value={bullets} onChange={e => setBullets(Number(e.target.value))} className="w-full border rounded p-1" />
+            </label>
+            <label className="space-y-1">
+              <span className="block text-sm">Enemy HP</span>
+              <input type="number" value={hp} onChange={e => setHp(Number(e.target.value))} className="w-full border rounded p-1" />
+            </label>
+            <label className="space-y-1">
+              <span className="block text-sm">Enemy Armor</span>
+              <input type="number" value={armor} onChange={e => setArmor(Number(e.target.value))} className="w-full border rounded p-1" />
+            </label>
+            <label className="flex items-center space-x-2 mt-6">
+              <input type="checkbox" checked={penetrate} onChange={e => setPenetrate(e.target.checked)} />
+              <span>Using armor penetration item</span>
+            </label>
+          </div>
+          <button onClick={onCalc} className="bg-indigo-600 text-white px-4 py-1 rounded">Calculate</button>
+          {rows.length > 0 && (
+            <>
+              <div className="h-64">
+                <svg viewBox="0 0 100 100" className="w-full h-full bg-gray-50">
+                  <polyline fill="none" stroke="teal" strokeWidth="2" points={points} />
+                </svg>
+              </div>
+              <table className="w-full text-sm mt-4 border" >
+                <thead>
+                  <tr>
+                    <th className="border px-2 py-1">Damage %</th>
+                    <th className="border px-2 py-1">Shots</th>
+                    <th className="border px-2 py-1">Accumulated Damage</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((r, idx) => {
+                    const prev = idx > 0 ? rows[idx - 1].shots : r.shots
+                    const highlight = r.shots < prev
+                    return (
+                      <tr key={r.percent} className={highlight ? 'bg-yellow-100' : ''}>
+                        <td className="border px-2 py-1">{r.percent}%</td>
+                        <td className="border px-2 py-1">{r.shots}</td>
+                        <td className="border px-2 py-1">{r.totalDamage.toFixed(1)}</td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/my-app/src/components/BreakPointCalculator.tsx
+++ b/my-app/src/components/BreakPointCalculator.tsx
@@ -15,16 +15,6 @@ export default function BreakPointCalculator() {
     setRows(calculateBreakpoints(damage, bullets, hp, armor, penetrate))
   }
 
-  const finiteRows = rows.filter(r => Number.isFinite(r.shots))
-  const maxShots = Math.max(...finiteRows.map(r => r.shots), 1)
-  const points = finiteRows
-    .map(r => {
-      const x = r.percent
-      const y = 100 - (r.shots / maxShots) * 100
-      return `${x},${y}`
-    })
-    .join(' ')
-
   return (
     <div className="bg-white rounded-xl shadow-lg">
       <button
@@ -59,35 +49,34 @@ export default function BreakPointCalculator() {
           </div>
           <button onClick={onCalc} className="bg-indigo-600 text-white px-4 py-1 rounded">Calculate</button>
           {rows.length > 0 && (
-            <>
-              <div className="h-64">
-                <svg viewBox="0 0 100 100" className="w-full h-full bg-gray-50">
-                  <polyline fill="none" stroke="teal" strokeWidth="2" points={points} />
-                </svg>
-              </div>
-              <table className="w-full text-sm mt-4 border" >
-                <thead>
-                  <tr>
-                    <th className="border px-2 py-1">Damage %</th>
-                    <th className="border px-2 py-1">Shots</th>
-                    <th className="border px-2 py-1">Accumulated Damage</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {rows.map((r, idx) => {
-                    const prev = idx > 0 ? rows[idx - 1].shots : r.shots
-                    const highlight = r.shots < prev
-                    return (
-                      <tr key={r.percent} className={highlight ? 'bg-yellow-100' : ''}>
-                        <td className="border px-2 py-1">{r.percent}%</td>
-                        <td className="border px-2 py-1">{r.shots}</td>
-                        <td className="border px-2 py-1">{r.totalDamage.toFixed(1)}</td>
-                      </tr>
-                    )
-                  })}
-                </tbody>
-              </table>
-            </>
+            <table className="w-full text-sm mt-4 border">
+              <thead>
+                <tr>
+                  <th className="border px-2 py-1">Damage %</th>
+                  <th className="border px-2 py-1">Per Bullet</th>
+                  <th className="border px-2 py-1">Per Shot</th>
+                  <th className="border px-2 py-1">Shots</th>
+                  <th className="border px-2 py-1">Accumulated</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r, idx) => {
+                  const prev = idx > 0 ? rows[idx - 1].shots : r.shots
+                  const highlight = r.shots < prev
+                  const dmgPerBullet = (damage * r.percent) / 100
+                  const dmgPerShot = dmgPerBullet * bullets
+                  return (
+                    <tr key={r.percent} className={highlight ? 'bg-yellow-100' : ''}>
+                      <td className="border px-2 py-1">{r.percent}%</td>
+                      <td className="border px-2 py-1">{dmgPerBullet.toFixed(1)}</td>
+                      <td className="border px-2 py-1">{dmgPerShot.toFixed(1)}</td>
+                      <td className="border px-2 py-1">{r.shots}</td>
+                      <td className="border px-2 py-1">{r.totalDamage.toFixed(1)}</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
           )}
         </div>
       )}

--- a/my-app/src/utils/__tests__/breakpoint.test.ts
+++ b/my-app/src/utils/__tests__/breakpoint.test.ts
@@ -1,0 +1,9 @@
+import { calculateBreakpoints } from '../breakpoint'
+
+describe('calculateBreakpoints', () => {
+  it('computes decreasing shots with higher percent', () => {
+    const rows = calculateBreakpoints(10, 1, 20, 0, false)
+    const shots = rows.map(r => r.shots)
+    expect(shots[0]).toBeGreaterThan(shots[shots.length - 1])
+  })
+})

--- a/my-app/src/utils/__tests__/breakpoint.test.ts
+++ b/my-app/src/utils/__tests__/breakpoint.test.ts
@@ -6,4 +6,9 @@ describe('calculateBreakpoints', () => {
     const shots = rows.map(r => r.shots)
     expect(shots[0]).toBeGreaterThan(shots[shots.length - 1])
   })
+
+  it('handles zero damage without infinite loop', () => {
+    const rows = calculateBreakpoints(0, 1, 20, 0, false)
+    expect(rows[0].shots).toBe(Infinity)
+  })
 })

--- a/my-app/src/utils/__tests__/breakpoint.test.ts
+++ b/my-app/src/utils/__tests__/breakpoint.test.ts
@@ -3,6 +3,9 @@ import { calculateBreakpoints } from '../breakpoint'
 describe('calculateBreakpoints', () => {
   it('computes decreasing shots with higher percent', () => {
     const rows = calculateBreakpoints(10, 1, 20, 0, false)
+    expect(rows.length).toBe(21)
+    expect(rows[0].percent).toBe(100)
+    expect(rows[rows.length - 1].percent).toBe(200)
     const shots = rows.map(r => r.shots)
     expect(shots[0]).toBeGreaterThan(shots[shots.length - 1])
   })

--- a/my-app/src/utils/breakpoint.ts
+++ b/my-app/src/utils/breakpoint.ts
@@ -51,7 +51,7 @@ export function calculateBreakpoints(
   penetrate: boolean
 ): BreakPointResult[] {
   const results: BreakPointResult[] = [];
-  for (let p = 0; p <= 100; p += 5) {
+  for (let p = 100; p <= 200; p += 5) {
     const scale = damage * (p / 100);
     const { shots, totalDamage } = shotsToKill(scale, bulletsPerShot, hp, armor, penetrate);
     results.push({ percent: p, shots, totalDamage });

--- a/my-app/src/utils/breakpoint.ts
+++ b/my-app/src/utils/breakpoint.ts
@@ -18,6 +18,9 @@ export function shotsToKill(
   armor: number,
   penetrate: boolean
 ): { shots: number; totalDamage: number } {
+  if (damage <= 0 || bulletsPerShot <= 0) {
+    return { shots: Infinity, totalDamage: 0 };
+  }
   let remainingHp = hp;
   let remainingArmor = armor;
   let shots = 0;

--- a/my-app/src/utils/breakpoint.ts
+++ b/my-app/src/utils/breakpoint.ts
@@ -1,0 +1,57 @@
+export interface BreakPointResult {
+  percent: number;
+  shots: number;
+  totalDamage: number;
+}
+
+function armorReducedDamage(dmg: number, penetrate: boolean): number {
+  const flat = penetrate ? 3.5 : 7;
+  const cap = penetrate ? 0.25 : 0.5;
+  const reduction = Math.min(flat, dmg * cap);
+  return dmg - reduction;
+}
+
+export function shotsToKill(
+  damage: number,
+  bulletsPerShot: number,
+  hp: number,
+  armor: number,
+  penetrate: boolean
+): { shots: number; totalDamage: number } {
+  let remainingHp = hp;
+  let remainingArmor = armor;
+  let shots = 0;
+  let total = 0;
+  while (remainingHp > 0) {
+    shots++;
+    for (let i = 0; i < bulletsPerShot; i++) {
+      let dmg = damage;
+      if (remainingArmor > 0) {
+        dmg = armorReducedDamage(dmg, penetrate);
+        const toArmor = Math.min(dmg, remainingArmor);
+        remainingArmor -= toArmor;
+        dmg -= toArmor;
+      }
+      remainingHp -= dmg;
+      total += damage;
+      if (remainingHp <= 0) break;
+    }
+  }
+  return { shots, totalDamage: total };
+}
+
+export function calculateBreakpoints(
+  damage: number,
+  bulletsPerShot: number,
+  hp: number,
+  armor: number,
+  penetrate: boolean
+): BreakPointResult[] {
+  const results: BreakPointResult[] = [];
+  for (let p = 0; p <= 100; p += 5) {
+    const scale = damage * (p / 100);
+    const { shots, totalDamage } = shotsToKill(scale, bulletsPerShot, hp, armor, penetrate);
+    results.push({ percent: p, shots, totalDamage });
+  }
+  return results;
+}


### PR DESCRIPTION
## Summary
- add BreakPointCalculator component
- compute breakpoint logic in new utils module
- show calculator below optimizer view
- test breakpoint utility

## Testing
- `npm test`
- `npm run coverage` *(fails: no coverage summary output)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6848f876da14832bb9199194d8c5612a