### PR TITLE
Improve minimum value UI and chip styling

### DIFF
--- a/my-app/src/components/Chip.tsx
+++ b/my-app/src/components/Chip.tsx
@@ -1,0 +1,21 @@
+interface ChipProps {
+  label: string;
+  onRemove?: () => void;
+}
+
+export default function Chip({ label, onRemove }: ChipProps) {
+  return (
+    <span className="flex items-center gap-2 rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800">
+      {label}
+      {onRemove && (
+        <button
+          type="button"
+          className="text-red-500 hover:text-red-700 text-lg leading-none"
+          onClick={onRemove}
+        >
+          &times;
+        </button>
+      )}
+    </span>
+  );
+}

--- a/my-app/src/components/input/AvoidSection.tsx
+++ b/my-app/src/components/input/AvoidSection.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import SearchableDropdown from '../SearchableDropdown';
+import Chip from '../Chip';
 import { useAppDispatch, useAppSelector } from '../../hooks';
 import { addAvoid, removeAvoid } from '../../slices/inputSlice';
 import type { Item } from '../../types';
@@ -52,19 +53,11 @@ export default function AvoidSection({ items }: Props) {
           {avoid.map(id => {
             const item = items.find(it => (it.id || it.name) === id);
             return (
-              <span
+              <Chip
                 key={id}
-                className="flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-800"
-              >
-                {item ? item.name : id}
-                <button
-                  type="button"
-                  className="ml-1 text-red-500 hover:text-red-700"
-                  onClick={() => dispatch(removeAvoid(id))}
-                >
-                  &times;
-                </button>
-              </span>
+                label={item ? item.name : id}
+                onRemove={() => dispatch(removeAvoid(id))}
+              />
             );
           })}
         </div>

--- a/my-app/src/components/input/MinValueSection.tsx
+++ b/my-app/src/components/input/MinValueSection.tsx
@@ -1,5 +1,6 @@
 import SearchableDropdown from '../SearchableDropdown';
 import NumberInput from '../NumberInput';
+import Chip from '../Chip';
 import { useAppDispatch, useAppSelector } from '../../hooks';
 import {
   toggleMinValueEnabled,
@@ -41,14 +42,7 @@ export default function MinValueSection({ attrTypes }: Props) {
           {groups.map((g, idx) => (
             <div key={idx} className="rounded border p-3 space-y-2">
               <div className="flex items-center gap-2">
-                <SearchableDropdown
-                  label="Add Attribute"
-                  placeholder="Add attribute"
-                  options={options.filter(o => !g.attrs.includes(o.value))}
-                  value=""
-                  onChange={val => dispatch(addAttrToGroup({ index: idx, attr: val }))}
-                  className="flex-grow"
-                />
+                <span className="text-sm font-medium text-gray-700">Target Value:</span>
                 <NumberInput
                   value={g.value}
                   onChange={val => dispatch(setMinGroupValue({ index: idx, value: val }))}
@@ -68,19 +62,22 @@ export default function MinValueSection({ attrTypes }: Props) {
                   </button>
                 )}
               </div>
+              <SearchableDropdown
+                label="Add Attribute"
+                placeholder="Add attribute"
+                options={options.filter(o => !g.attrs.includes(o.value))}
+                value=""
+                onChange={val => dispatch(addAttrToGroup({ index: idx, attr: val }))}
+                className="w-full"
+              />
               {g.attrs.length > 0 && (
                 <div className="flex flex-wrap gap-2">
                   {g.attrs.map(a => (
-                    <span key={a} className="flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-800">
-                      {attributeValueToLabel(a)}
-                      <button
-                        type="button"
-                        className="ml-1 text-red-500 hover:text-red-700"
-                        onClick={() => dispatch(removeAttrFromGroup({ index: idx, attr: a }))}
-                      >
-                        &times;
-                      </button>
-                    </span>
+                    <Chip
+                      key={a}
+                      label={attributeValueToLabel(a)}
+                      onRemove={() => dispatch(removeAttrFromGroup({ index: idx, attr: a }))}
+                    />
                   ))}
                 </div>
               )}


### PR DESCRIPTION
## Summary
- add reusable `Chip` component with larger text and close button
- use `Chip` to render items in AvoidSection
- redesign MinValueSection layout to show target value label above attribute selector

## Testing
- `npm run build`
- `npm run coverage`

------
https://chatgpt.com/codex/tasks/task_e_6848f9bd99c0832bbabb5c112c6cc79d