### PR TITLE
Add ability to toggle avoid items

### DIFF
--- a/my-app/src/Optimizer.tsx
+++ b/my-app/src/Optimizer.tsx
@@ -22,6 +22,7 @@ export default function Optimizer() {
     equipped,
     toBuy,
     avoid,
+    avoidEnabled,
     weights,
     minValueEnabled,
     minAttrGroups,
@@ -123,7 +124,7 @@ export default function Optimizer() {
       it =>
         (!it.character || it.character === hero) &&
         !equipped.includes(it.id ?? '') &&
-        !avoid.includes(it.id ?? '') &&
+        (!avoidEnabled || !avoid.includes(it.id ?? '')) &&
         it.attributes.some(a => selectedAttrs.has(a.type))
     );
     const needed = toBuy;

--- a/my-app/src/components/input/AvoidSection.tsx
+++ b/my-app/src/components/input/AvoidSection.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import SearchableDropdown from '../SearchableDropdown';
 import Chip from '../Chip';
 import { useAppDispatch, useAppSelector } from '../../hooks';
-import { addAvoid, removeAvoid } from '../../slices/inputSlice';
+import { addAvoid, removeAvoid, toggleAvoidEnabled } from '../../slices/inputSlice';
 import type { Item } from '../../types';
 import { rarityColor } from '../../utils/optimizer';
 import { sortItemsByRarityAndName } from '../../utils/item';
@@ -13,54 +13,71 @@ interface Props {
 
 export default function AvoidSection({ items }: Props) {
   const avoid = useAppSelector(state => state.input.present.avoid);
+  const enabled = useAppSelector(state => state.input.present.avoidEnabled);
   const dispatch = useAppDispatch();
   const [selected, setSelected] = useState('');
 
   return (
     <div>
-      <label className="block text-sm font-medium text-gray-700">Avoid Item</label>
-      <div className="flex items-center gap-2 mt-1">
-        <SearchableDropdown
-          label="Avoid Item"
-          placeholder="Select item"
-          options={[
-            { value: '', label: 'Select item' },
-            ...items.sort(sortItemsByRarityAndName).map(it => ({
-              value: it.id || it.name,
-              label: `${it.name} (${it.cost})`,
-              color: rarityColor(it.rarity),
-            })),
-          ]}
-          value={selected}
-          onChange={setSelected}
-          className="flex-grow"
+      <label className="block text-sm font-medium text-gray-700">Avoid Items</label>
+      <div className="flex items-center gap-2 mt-1 mb-2">
+        <input
+          id="avoid-toggle"
+          type="checkbox"
+          checked={enabled}
+          onChange={() => dispatch(toggleAvoidEnabled())}
+          className="h-4 w-4 text-teal-600 border-gray-300 rounded focus:ring-teal-500"
         />
-        <button
-          type="button"
-          className="rounded bg-gray-200 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-300"
-          onClick={() => {
-            if (selected) {
-              dispatch(addAvoid(selected));
-              setSelected('');
-            }
-          }}
-        >
-          Add
-        </button>
+        <label htmlFor="avoid-toggle" className="text-sm text-gray-700 select-none">
+          Enable Avoid Items
+        </label>
       </div>
-      {avoid.length > 0 && (
-        <div className="flex flex-wrap gap-2 mt-2">
-          {avoid.map(id => {
-            const item = items.find(it => (it.id || it.name) === id);
-            return (
-              <Chip
-                key={id}
-                label={item ? item.name : id}
-                onRemove={() => dispatch(removeAvoid(id))}
-              />
-            );
-          })}
-        </div>
+      {enabled && (
+        <>
+          <div className="flex items-center gap-2">
+            <SearchableDropdown
+              label="Avoid Item"
+              placeholder="Select item"
+              options={[
+                { value: '', label: 'Select item' },
+                ...items.sort(sortItemsByRarityAndName).map(it => ({
+                  value: it.id || it.name,
+                  label: `${it.name} (${it.cost})`,
+                  color: rarityColor(it.rarity),
+                })),
+              ]}
+              value={selected}
+              onChange={setSelected}
+              className="flex-grow"
+            />
+            <button
+              type="button"
+              className="rounded bg-gray-200 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-300"
+              onClick={() => {
+                if (selected) {
+                  dispatch(addAvoid(selected));
+                  setSelected('');
+                }
+              }}
+            >
+              Add
+            </button>
+          </div>
+          {avoid.length > 0 && (
+            <div className="flex flex-wrap gap-2 mt-2">
+              {avoid.map(id => {
+                const item = items.find(it => (it.id || it.name) === id);
+                return (
+                  <Chip
+                    key={id}
+                    label={item ? item.name : id}
+                    onRemove={() => dispatch(removeAvoid(id))}
+                  />
+                );
+              })}
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/my-app/src/slices/__tests__/inputSlice.test.ts
+++ b/my-app/src/slices/__tests__/inputSlice.test.ts
@@ -2,6 +2,7 @@ import reducer, {
   setHero,
   addAvoid,
   removeAvoid,
+  toggleAvoidEnabled,
   addWeightRow,
   setWeightType,
   toggleMinValueEnabled,
@@ -36,6 +37,11 @@ test('addWeightRow and setWeightType modify weights', () => {
 test('toggleMinValueEnabled switches boolean', () => {
   const state = reducer(initialState, toggleMinValueEnabled());
   expect(state.minValueEnabled).toBe(true);
+});
+
+test('toggleAvoidEnabled switches boolean', () => {
+  const state = reducer(initialState, toggleAvoidEnabled());
+  expect(state.avoidEnabled).toBe(true);
 });
 
 test('min attribute group reducers modify groups', () => {

--- a/my-app/src/slices/inputSlice.ts
+++ b/my-app/src/slices/inputSlice.ts
@@ -8,6 +8,7 @@ export interface InputState {
   equipped: (string | '')[];
   toBuy: number;
   avoid: string[];
+  avoidEnabled: boolean;
   weights: WeightRow[];
   error: string;
   minValueEnabled: boolean;
@@ -20,6 +21,7 @@ const initialState: InputState = {
   equipped: Array(6).fill(''),
   toBuy: 6,
   avoid: [],
+  avoidEnabled: false,
   weights: [{ type: '', weight: 1 }],
   error: '',
   minValueEnabled: false,
@@ -49,6 +51,9 @@ const inputSlice = createSlice({
     },
     removeAvoid(state, action: PayloadAction<string>) {
       state.avoid = state.avoid.filter((id) => id !== action.payload);
+    },
+    toggleAvoidEnabled(state) {
+      state.avoidEnabled = !state.avoidEnabled;
     },
     setWeightType(state, action: PayloadAction<{ index: number; type: string }>) {
       state.weights[action.payload.index].type = action.payload.type;
@@ -109,6 +114,7 @@ export const {
   setToBuy,
   addAvoid,
   removeAvoid,
+  toggleAvoidEnabled,
   setWeightType,
   setWeightValue,
   addWeightRow,


### PR DESCRIPTION
## Summary
- allow enabling and disabling avoid list with a checkbox
- store `avoidEnabled` state in Redux with reducer
- respect `avoidEnabled` when filtering candidate items
- test new `toggleAvoidEnabled` reducer

## Testing
- `npm run build`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_68490cee47b0832b81d031bb12665deb