### PR TITLE
Improve SearchableDropdown

### DIFF
--- a/my-app/src/components/SearchableDropdown.tsx
+++ b/my-app/src/components/SearchableDropdown.tsx
@@ -21,6 +21,7 @@ export default function SearchableDropdown({ label, options, value, onChange, pl
   const [search, setSearch] = useState('');
   const dropdownRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const selected = options.find(o => o.value === value);
   const displayedLabel = selected?.label || placeholder;
@@ -44,6 +45,13 @@ export default function SearchableDropdown({ label, options, value, onChange, pl
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
+  // Focus the search input when dropdown opens
+  useEffect(() => {
+    if (isOpen && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isOpen]);
+
   useEffect(() => {
     if (!isOpen || !triggerRef.current) return;
     const triggerRect = triggerRef.current.getBoundingClientRect();
@@ -66,7 +74,11 @@ export default function SearchableDropdown({ label, options, value, onChange, pl
         <button
           type="button"
           className="flex-grow px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:relative text-left"
-          onClick={() => setIsOpen(!isOpen)}
+          onClick={() => {
+            const next = !isOpen;
+            setIsOpen(next);
+            if (next) setSearch('');
+          }}
           ref={triggerRef}
         >
           <span style={{ color: displayedColor || 'inherit' }}>{displayedLabel}</span>
@@ -75,7 +87,11 @@ export default function SearchableDropdown({ label, options, value, onChange, pl
           type="button"
           className="flex-shrink-0 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 focus:relative"
           aria-label="Menu"
-          onClick={() => setIsOpen(!isOpen)}
+          onClick={() => {
+            const next = !isOpen;
+            setIsOpen(next);
+            if (next) setSearch('');
+          }}
         >
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="size-4">
             <path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
@@ -89,10 +105,17 @@ export default function SearchableDropdown({ label, options, value, onChange, pl
               <p className="sticky top-0 bg-white px-3 py-2 text-xs uppercase text-gray-500 border-b border-gray-200 z-20">{label}</p>
               <input
                 type="text"
+                ref={inputRef}
                 className="mx-3 my-2 w-[calc(100%-1.5rem)] rounded border border-gray-300 px-2 py-1 text-sm"
                 placeholder="Search..."
                 value={search}
                 onChange={e => setSearch(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && filteredOptions.length === 1) {
+                    e.preventDefault();
+                    handleSelect(filteredOptions[0].value);
+                  }
+                }}
               />
               {filteredOptions.map(option => (
                 <a

--- a/my-app/src/components/__tests__/SearchableDropdown.test.tsx
+++ b/my-app/src/components/__tests__/SearchableDropdown.test.tsx
@@ -1,0 +1,33 @@
+/* @vitest-environment jsdom */
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import SearchableDropdown from '../SearchableDropdown';
+
+describe('SearchableDropdown', () => {
+  const options = [
+    { value: '1', label: 'One' },
+    { value: '2', label: 'Two' },
+  ];
+
+  it('focuses search input when opened', () => {
+    const { getAllByRole, getByPlaceholderText } = render(
+      <SearchableDropdown label="Test" options={options} value="" onChange={() => {}} />
+    );
+    fireEvent.click(getAllByRole('button')[0]);
+    const input = getByPlaceholderText('Search...');
+    expect(input).toHaveFocus();
+  });
+
+  it('accepts single result with enter key', () => {
+    const handleChange = vi.fn();
+    const { getAllByRole, getByPlaceholderText } = render(
+      <SearchableDropdown label="Test" options={options} value="" onChange={handleChange} />
+    );
+    fireEvent.click(getAllByRole('button')[0]);
+    const input = getByPlaceholderText('Search...');
+    fireEvent.change(input, { target: { value: 'One' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(handleChange).toHaveBeenCalledWith('1');
+  });
+});


### PR DESCRIPTION
## Summary
- auto-focus search input on open and clear previous query
- accept the single search result by pressing Enter
- test SearchableDropdown focus & enter behaviour

## Testing
- `npm run build`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_68490ed7104c832b9b3af2b109bd79a8