### PR TITLE
Fix Min Attribute candidate filter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ This app is an Overwatch tool that helps users optimize their in-game item build
   - Item data are loaded from `src/data.json` and can be overridden via `src/overrides.json`. Do not edit `data.json` directly.
   - Custom item attribute overrides live in `src/overrides.json` so that balance adjustments can be tested without changing the base data file.
   - Minimum attribute totals can be enforced from `src/components/input/MinValueSection.tsx`.
+  - The result breakdown includes attributes referenced in Minimum Attribute groups, implemented via `buildBreakdown` in `src/utils/optimizer.ts`.
   - A break point calculator in `src/components/BreakPointCalculator.tsx` helps analyze bullet damage thresholds.
 
 # File Overview

--- a/my-app/src/Optimizer.tsx
+++ b/my-app/src/Optimizer.tsx
@@ -8,6 +8,7 @@ import {
   scoreFromMap,
   meetsMinGroups,
   collectRelevantAttributes,
+  buildBreakdown,
 } from './utils/optimizer';
 import rawData from './data.json?raw';
 import overridesRaw from './overrides.json?raw';
@@ -198,11 +199,18 @@ export default function Optimizer() {
       .filter(c => (preferHighCost ? c.cost < best.cost : c.cost > best.cost))
       .sort((a, b) => preferHighCost ? b.cost - a.cost : a.cost - b.cost);
     const totalMap = aggregate([...best.items, ...eqItems]);
-    const breakdown = weights.map(w => {
-      const sum = totalMap.get(w.type) ?? 0;
-      return { type: w.type, sum, contrib: sum * w.weight };
+    const breakdown = buildBreakdown(
+      totalMap,
+      weights,
+      minValueEnabled,
+      minAttrGroups
+    );
+    setResults({
+      items: best.items,
+      cost: best.cost,
+      score: scoreFromMap(totalMap, weights),
+      breakdown,
     });
-    setResults({ items: best.items, cost: best.cost, score: scoreFromMap(totalMap, weights), breakdown });
     setAlternatives(alt.map(c => ({ ...c, score: calcScore([...c.items, ...eqItems]) })));
   }
 

--- a/my-app/src/Optimizer.tsx
+++ b/my-app/src/Optimizer.tsx
@@ -3,7 +3,12 @@ import type { Item, ResultCombo, RootData, ItemOverride } from './types';
 import InputSection from './components/InputSection';
 import ResultsSection from './components/ResultsSection';
 import BreakPointCalculator from './components/BreakPointCalculator';
-import { aggregate, scoreFromMap, meetsMinGroups } from './utils/optimizer';
+import {
+  aggregate,
+  scoreFromMap,
+  meetsMinGroups,
+  collectRelevantAttributes,
+} from './utils/optimizer';
 import rawData from './data.json?raw';
 import overridesRaw from './overrides.json?raw';
 import { sortAttributes } from './utils/attribute';
@@ -120,7 +125,11 @@ export default function Optimizer() {
       dispatch(setError('Equipped items cost exceeds total cash'));
       return;
     }
-    const selectedAttrs = new Set(weights.map(w => w.type));
+    const selectedAttrs = collectRelevantAttributes(
+      weights,
+      minValueEnabled,
+      minAttrGroups
+    );
     const candidate = data.filter(
       it =>
         (!it.character || it.character === hero) &&

--- a/my-app/src/utils/__tests__/breakdown.test.ts
+++ b/my-app/src/utils/__tests__/breakdown.test.ts
@@ -1,0 +1,27 @@
+import { buildBreakdown } from '../optimizer';
+import type { WeightRow, MinAttrGroup } from '../../types';
+
+test('buildBreakdown adds min attributes', () => {
+  const map = new Map<string, number>([
+    ['AP', 5],
+    ['WP', 3],
+  ]);
+  const weights: WeightRow[] = [{ type: 'AP', weight: 1 }];
+  const groups: MinAttrGroup[] = [{ attrs: ['WP'], value: 5 }];
+  const rows = buildBreakdown(map, weights, true, groups);
+  expect(rows).toEqual([
+    { type: 'AP', sum: 5, contrib: 5 },
+    { type: 'WP', sum: 3, contrib: 0 },
+  ]);
+});
+
+test('buildBreakdown ignores groups when disabled', () => {
+  const map = new Map<string, number>([
+    ['AP', 5],
+    ['WP', 3],
+  ]);
+  const weights: WeightRow[] = [{ type: 'AP', weight: 1 }];
+  const groups: MinAttrGroup[] = [{ attrs: ['WP'], value: 5 }];
+  const rows = buildBreakdown(map, weights, false, groups);
+  expect(rows).toEqual([{ type: 'AP', sum: 5, contrib: 5 }]);
+});

--- a/my-app/src/utils/__tests__/relevantAttrs.test.ts
+++ b/my-app/src/utils/__tests__/relevantAttrs.test.ts
@@ -1,0 +1,18 @@
+import { collectRelevantAttributes } from '../optimizer';
+import type { WeightRow, MinAttrGroup } from '../../types';
+
+test('collectRelevantAttributes merges weights and min groups', () => {
+  const weights: WeightRow[] = [{ type: 'AP', weight: 1 }];
+  const groups: MinAttrGroup[] = [{ attrs: ['WP'], value: 5 }];
+  const set = collectRelevantAttributes(weights, true, groups);
+  expect(set.has('AP')).toBe(true);
+  expect(set.has('WP')).toBe(true);
+});
+
+test('collectRelevantAttributes ignores groups when disabled', () => {
+  const weights: WeightRow[] = [{ type: 'AP', weight: 1 }];
+  const groups: MinAttrGroup[] = [{ attrs: ['WP'], value: 5 }];
+  const set = collectRelevantAttributes(weights, false, groups);
+  expect(set.has('AP')).toBe(true);
+  expect(set.has('WP')).toBe(false);
+});

--- a/my-app/src/utils/optimizer.ts
+++ b/my-app/src/utils/optimizer.ts
@@ -59,3 +59,23 @@ export function collectRelevantAttributes(
   set.delete('');
   return set;
 }
+
+export function buildBreakdown(
+  map: Map<string, number>,
+  weights: WeightRow[],
+  enabled: boolean,
+  groups: MinAttrGroup[]
+) {
+  const attrs = collectRelevantAttributes(weights, enabled, groups);
+  const rows: { type: string; sum: number; contrib: number }[] = [];
+  weights.forEach(w => {
+    const sum = map.get(w.type) ?? 0;
+    rows.push({ type: w.type, sum, contrib: sum * w.weight });
+    attrs.delete(w.type);
+  });
+  attrs.forEach(type => {
+    const sum = map.get(type) ?? 0;
+    rows.push({ type, sum, contrib: 0 });
+  });
+  return rows;
+}

--- a/my-app/src/utils/optimizer.ts
+++ b/my-app/src/utils/optimizer.ts
@@ -44,3 +44,18 @@ export function meetsMinGroups(items: Item[], groups: MinAttrGroup[]) {
     return sum >= g.value;
   });
 }
+
+export function collectRelevantAttributes(
+  weights: WeightRow[],
+  enabled: boolean,
+  groups: MinAttrGroup[]
+) {
+  const set = new Set(weights.map(w => w.type));
+  if (enabled) {
+    groups.forEach(g => {
+      g.attrs.forEach(a => set.add(a));
+    });
+  }
+  set.delete('');
+  return set;
+}


### PR DESCRIPTION
## Summary
- extend optimizer utilities with `collectRelevantAttributes`
- use new util to include minimum attribute types when filtering items
- test `collectRelevantAttributes`

## Testing
- `npm install`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684912d1fa0c832b952751e8389768e4