### PR TITLE
Dynamic equipped items

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - Deployment is manual only; you can skip `npm run deploy` in this environment.
 - **Do not open `my-app/data.json`**. Use `src/types.ts` for the data shape.
 - When add new features, update AGENTS.md with a brief description of the feature and its location in the codebase.
+- For any user-facing **add** operation, implement a corresponding **remove** action in the UI and Redux slice.
 
 
 # Project Overview
@@ -44,3 +45,4 @@ This app is an Overwatch tool that helps users optimize their in-game item build
 - Equipped item rows now start with two slots and users can add up to six using
   the "Add Slot" button in `src/components/input/EquippedSection.tsx`. The
   Redux action `addEquippedSlot` lives in `src/slices/inputSlice.ts`.
+- Each equipped row shows a remove button to delete slots via `removeEquippedSlot`.

--- a/my-app/src/components/input/EquippedSection.tsx
+++ b/my-app/src/components/input/EquippedSection.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import SearchableDropdown from '../SearchableDropdown';
 import { useAppDispatch, useAppSelector } from '../../hooks';
-import { setEquipped, addEquippedSlot } from '../../slices/inputSlice';
+import { setEquipped, addEquippedSlot, removeEquippedSlot } from '../../slices/inputSlice';
 import type { Item } from '../../types';
 import { rarityColor } from '../../utils/optimizer';
 import { attributeValueToLabel } from '../../utils/attribute';
@@ -41,27 +41,39 @@ export default function EquippedSection({ items }: Props) {
       {useEquipped && (
         <div className="space-y-4 mt-1">
           {equipped.map((id, idx) => (
-            <SearchableDropdown
-              key={idx}
-              label={`Equipped Slot ${idx + 1}`}
-              placeholder="None"
-              options={[
-                { value: '', label: 'None' },
-                ...items
-                  .sort(sortItemsByRarityAndName)
-                  .map(it => ({
-                    value: it.id || it.name,
-                    label: `${it.name} (${it.cost}) ${it.attributes
-                      .filter(a => a.type !== 'description')
-                      .map(a => `${attributeValueToLabel(a.type)}-${a.value}`)
-                      .join(', ')}`,
-                    color: rarityColor(it.rarity),
-                  })),
-              ]}
-              value={id}
-              onChange={value => dispatch(setEquipped({ index: idx, id: value }))}
-              className="w-full"
-            />
+            <div key={idx} className="flex items-center gap-2">
+              <SearchableDropdown
+                label={`Equipped Slot ${idx + 1}`}
+                placeholder="None"
+                options={[
+                  { value: '', label: 'None' },
+                  ...items
+                    .sort(sortItemsByRarityAndName)
+                    .map(it => ({
+                      value: it.id || it.name,
+                      label: `${it.name} (${it.cost}) ${it.attributes
+                        .filter(a => a.type !== 'description')
+                        .map(a => `${attributeValueToLabel(a.type)}-${a.value}`)
+                        .join(', ')}`,
+                      color: rarityColor(it.rarity),
+                    })),
+                ]}
+                value={id}
+                onChange={value => dispatch(setEquipped({ index: idx, id: value }))}
+                className="flex-grow"
+              />
+              {equipped.length > 2 && (
+                <button
+                  type="button"
+                  className="flex-shrink-0 rounded p-2 text-gray-400 hover:bg-red-50 hover:text-red-600"
+                  onClick={() => dispatch(removeEquippedSlot(idx))}
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                </button>
+              )}
+            </div>
           ))}
           {equipped.length < 6 && (
             <button

--- a/my-app/src/slices/__tests__/inputSlice.test.ts
+++ b/my-app/src/slices/__tests__/inputSlice.test.ts
@@ -11,6 +11,8 @@ import reducer, {
   addAttrToGroup,
   removeAttrFromGroup,
   removeMinGroup,
+  addEquippedSlot,
+  removeEquippedSlot,
 } from '../inputSlice';
 
 const initialState = reducer(undefined, { type: 'init' } as any);
@@ -55,4 +57,11 @@ test('min attribute group reducers modify groups', () => {
   expect(state.minAttrGroups[0].attrs).not.toContain('AP');
   state = reducer(state, removeMinGroup(0));
   expect(state.minAttrGroups).toHaveLength(0);
+});
+
+test('addEquippedSlot and removeEquippedSlot modify equipped array', () => {
+  let state = reducer(initialState, addEquippedSlot());
+  expect(state.equipped).toHaveLength(3);
+  state = reducer(state, removeEquippedSlot(2));
+  expect(state.equipped).toHaveLength(2);
 });

--- a/my-app/src/slices/inputSlice.ts
+++ b/my-app/src/slices/inputSlice.ts
@@ -46,6 +46,11 @@ const inputSlice = createSlice({
         state.equipped.push('');
       }
     },
+    removeEquippedSlot(state, action: PayloadAction<number>) {
+      if (state.equipped.length > 2) {
+        state.equipped.splice(action.payload, 1);
+      }
+    },
     setToBuy(state, action: PayloadAction<number>) {
       state.toBuy = action.payload;
     },
@@ -132,6 +137,7 @@ export const {
   addAttrToGroup,
   removeAttrFromGroup,
   addEquippedSlot,
+  removeEquippedSlot,
 } = inputSlice.actions;
 
 export default inputSlice.reducer;


### PR DESCRIPTION
## Summary
- default to two equipped item rows
- allow adding up to six rows with `Add Slot`
- document equipped item slots in `AGENTS.md`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68491330a250832b8f61e5aca2acf7a0