### PR TITLE
Add avoid button to results

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,4 +9,6 @@
 2025-06-10  Redux-powered undo/redo and input history dropdown  src/store
 2025-06-10  Searchable dropdowns for item and hero selection  src/components/Dropdowns
 2025-06-10  Support for custom item overrides via overrides.json  src/overrides.json
+
 2025-06-10  Modular React component structure with TypeScript, Vite, and TailwindCSS  src/
+2025-06-11  Add avoid button in results list  src/components/ResultsSection.tsx

--- a/my-app/src/components/ResultsSection.tsx
+++ b/my-app/src/components/ResultsSection.tsx
@@ -2,6 +2,8 @@ import type { Item, ResultCombo } from '../types';
 import { rarityColor } from '../utils/optimizer';
 import { stripHtmlTags } from '../utils/util';
 import { attributeValueToLabel } from '../utils/attribute';
+import { useAppDispatch, useAppSelector } from '../hooks';
+import { addAvoid, toggleAvoidEnabled } from '../slices/inputSlice';
 
 interface Props {
   eqItems: Item[];
@@ -12,6 +14,8 @@ interface Props {
 }
 
 export default function ResultsSection({ eqItems, eqCost, cash, results, alternatives }: Props) {
+  const dispatch = useAppDispatch();
+  const avoidEnabled = useAppSelector(state => state.input.present.avoidEnabled);
   return (
     <div className="space-y-6 bg-white rounded-xl shadow-lg p-6 sm:p-8">
       <h2 className="text-2xl font-bold text-gray-900 sm:text-3xl">Results</h2>
@@ -67,9 +71,22 @@ export default function ResultsSection({ eqItems, eqCost, cash, results, alterna
                     <strong className="font-semibold" style={{ color: rarityColor(it.rarity) }}>
                       {it.name}
                     </strong>
-                    <span className="text-sm font-mono rounded-full bg-indigo-50 text-indigo-600 px-2 py-0.5">
-                      {it.cost} G
-                    </span>
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-mono rounded-full bg-indigo-50 text-indigo-600 px-2 py-0.5">
+                        {it.cost} G
+                      </span>
+                      <button
+                        type="button"
+                        aria-label={`Avoid ${it.name}`}
+                        className="text-xs text-red-600 hover:underline"
+                        onClick={() => {
+                          if (!avoidEnabled) dispatch(toggleAvoidEnabled());
+                          dispatch(addAvoid(it.id || it.name));
+                        }}
+                      >
+                        Avoid
+                      </button>
+                    </div>
                   </div>
                   <ul className="mt-2 text-xs text-gray-600 space-y-1">
                     {it.attributes.map((a, idx) => (

--- a/my-app/src/components/__tests__/ResultsSection.test.tsx
+++ b/my-app/src/components/__tests__/ResultsSection.test.tsx
@@ -1,7 +1,9 @@
 /* @vitest-environment jsdom */
 import "@testing-library/jest-dom"
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, fireEvent } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import store from '../../store'
 import ResultsSection from '../ResultsSection'
 import type { Item, ResultCombo } from '../../types'
 
@@ -22,17 +24,33 @@ const alternatives: ResultCombo[] = [
 describe('ResultsSection', () => {
   it('renders placeholder when no results', () => {
     const { getByText } = render(
-      <ResultsSection eqItems={[]} eqCost={0} cash={0} results={null} alternatives={[]} />
+      <Provider store={store}>
+        <ResultsSection eqItems={[]} eqCost={0} cash={0} results={null} alternatives={[]} />
+      </Provider>
     )
     expect(getByText('No results yet')).toBeInTheDocument()
   })
 
   it('shows result details', () => {
     const { getByText } = render(
-      <ResultsSection eqItems={eqItems} eqCost={100} cash={200} results={results} alternatives={alternatives} />
+      <Provider store={store}>
+        <ResultsSection eqItems={eqItems} eqCost={100} cash={200} results={results} alternatives={alternatives} />
+      </Provider>
     )
     expect(getByText('Final Build')).toBeInTheDocument()
     expect(getByText('Alternative Builds')).toBeInTheDocument()
     expect(getByText('Cost: 40')).toBeInTheDocument()
+  })
+
+  it('adds item to avoid list on click', () => {
+    const { getByLabelText } = render(
+      <Provider store={store}>
+        <ResultsSection eqItems={eqItems} eqCost={100} cash={200} results={results} alternatives={[]} />
+      </Provider>
+    )
+    fireEvent.click(getByLabelText('Avoid Shield'))
+    const state = store.getState()
+    expect(state.input.present.avoid).toContain('2')
+    expect(state.input.present.avoidEnabled).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- add option to mark items from results as avoided
- test new behaviour
- document change in changelog

## Testing
- `npm test --prefix my-app --silent`

------
https://chatgpt.com/codex/tasks/task_e_684931c55f30832ba7a51e69a87be256