### PR TITLE
Fix damage calculator table on mobile

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,3 +13,4 @@
 2025-06-10  Modular React component structure with TypeScript, Vite, and TailwindCSS  src/
 2025-06-11  Add avoid button in results list  src/components/ResultsSection.tsx
 2025-06-11  Integrate ItemCard with avoid button  src/components
+2025-06-11  Fix mobile overflow in damage calculator table  src/components/BreakPointCalculator.tsx

--- a/my-app/src/components/BreakPointCalculator.tsx
+++ b/my-app/src/components/BreakPointCalculator.tsx
@@ -49,7 +49,8 @@ export default function BreakPointCalculator() {
           </div>
           <button onClick={onCalc} className="bg-indigo-600 text-white px-4 py-1 rounded">Calculate</button>
           {rows.length > 0 && (
-            <table className="w-full text-sm mt-4 border">
+            <div className="overflow-x-auto mt-4">
+              <table className="min-w-max w-full text-sm border">
               <thead>
                 <tr>
                   <th className="border px-2 py-1">Damage %</th>
@@ -76,7 +77,8 @@ export default function BreakPointCalculator() {
                   )
                 })}
               </tbody>
-            </table>
+              </table>
+            </div>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary
- fix Damage Calculator table overflow on small screens by wrapping in `overflow-x-auto`
- update changelog

## Testing
- `npm test --prefix my-app`

------
https://chatgpt.com/codex/tasks/task_e_68495e8d17e4832b9ed1b18e66e4c123