### PR TITLE
Fix results panel width on xl screens

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,3 +16,4 @@
 2025-06-11  Add default minimum value group for Health/Armor/Shield  src/slices/inputSlice.ts
 2025-06-11  Fix mobile overflow in damage calculator table  src/components/BreakPointCalculator.tsx
 2025-06-12  Display item descriptions without label  src/components/ResultsSection.tsx
+2025-06-12  Expand results panel space on xl screens  src/Optimizer.tsx

--- a/my-app/src/Optimizer.tsx
+++ b/my-app/src/Optimizer.tsx
@@ -222,7 +222,7 @@ export default function Optimizer() {
 
   return (
     <div className="bg-gray-50 min-h-screen p-4 sm:p-6 lg:p-8 space-y-8">
-      <div className="max-w-7xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-8">
+      <div className="max-w-7xl mx-auto grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-[2fr_3fr] gap-8">
         <InputSection
           heroes={heroes}
           attrTypes={attrTypes}

--- a/my-app/src/__tests__/Optimizer.test.tsx
+++ b/my-app/src/__tests__/Optimizer.test.tsx
@@ -1,0 +1,20 @@
+/* @vitest-environment jsdom */
+import '@testing-library/jest-dom'
+import React from 'react'
+import { render, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import store from '../store'
+import Optimizer from '../Optimizer'
+
+it('applies wider grid at xl screens', async () => {
+  const { container } = render(
+    <Provider store={store}>
+      <Optimizer />
+    </Provider>
+  )
+  await waitFor(() => {
+    expect(container.querySelector('.max-w-7xl.grid')).toBeInTheDocument()
+  })
+  const grid = container.querySelector('.max-w-7xl.grid')
+  expect(grid?.className).toContain('xl:grid-cols-[2fr_3fr]')
+})

--- a/my-app/src/slices/__tests__/inputSlice.test.ts
+++ b/my-app/src/slices/__tests__/inputSlice.test.ts
@@ -14,8 +14,9 @@ import reducer, {
   addEquippedSlot,
   removeEquippedSlot,
 } from '../inputSlice';
+import type { AnyAction } from '@reduxjs/toolkit';
 
-const initialState = reducer(undefined, { type: 'init' } as any);
+const initialState = reducer(undefined, { type: 'init' } as AnyAction);
 
 test('setHero updates hero field', () => {
   const state = reducer(initialState, setHero('Reaper'));


### PR DESCRIPTION
## Summary
- widen results panel on extra large screens with custom grid
- test for layout class in Optimizer
- fix lint error in inputSlice tests
- update changelog

## Testing
- `npm run lint`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684a854f3ae8832b854dbd37df8d84ab