### PR TITLE
Fix mobile layout issues

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,3 +16,4 @@
 2025-06-11  Add default minimum value group for Health/Armor/Shield  src/slices/inputSlice.ts
 2025-06-11  Fix mobile overflow in damage calculator table  src/components/BreakPointCalculator.tsx
 2025-06-12  Display item descriptions without label  src/components/ResultsSection.tsx
+2025-06-12  Fix mobile layout issues and disable iOS input zoom  src/components

--- a/my-app/src/components/SliderRange.tsx
+++ b/my-app/src/components/SliderRange.tsx
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useState } from "react";
+
+interface SliderRangeProps {
+  value: number;
+  onChange: (value: number) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+  className?: string;
+  label?: string;
+  showValue?: boolean;
+  disabled?: boolean;
+}
+
+export default function SliderRange({
+  value,
+  onChange,
+  min = 0,
+  max = 100,
+  step = 1,
+  className,
+  label,
+  showValue = true,
+  disabled = false
+}: SliderRangeProps) {
+  const [sliderValue, setSliderValue] = useState<number>(value);
+
+  useEffect(() => {
+    // Sync internal state if parent value changes
+    setSliderValue(value);
+  }, [value]);
+
+  const handleSliderChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = Number(e.target.value);
+    setSliderValue(newValue);
+    onChange(newValue);
+  }, [onChange]);
+
+  // Calculate percentage for styling
+  const percentage = ((sliderValue - min) / (max - min)) * 100;
+
+  return (
+    <div className={`relative ${className || ''}`}>
+      {label && (
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+          {label}
+          {showValue && (
+            <span className="ml-2 text-indigo-600 dark:text-indigo-400 font-semibold">
+              {sliderValue}
+            </span>
+          )}
+        </label>
+      )}
+
+      <div className="relative">
+        {/* Slider track */}
+        <div className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg relative overflow-hidden">
+          {/* Progress fill */}
+          <div
+            className="h-full bg-gradient-to-r from-indigo-500 to-indigo-600 dark:from-indigo-400 dark:to-indigo-500 rounded-lg transition-all duration-150 ease-out"
+            style={{ width: `${percentage}%` }}
+          />
+        </div>
+
+        {/* Slider input - make sure it overlays the track and thumb for full interactivity */}
+        <input
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={sliderValue}
+          onChange={handleSliderChange}
+          disabled={disabled}
+          className={`absolute top-1/2 left-0 w-full h-6 -translate-y-1/2 z-20 appearance-none bg-transparent focus:outline-none ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'}`}
+          aria-label={label || `Slider from ${min} to ${max}`}
+          style={{ pointerEvents: disabled ? 'none' : 'auto' }}
+        />
+
+        {/* Slider thumb (visual only) */}
+
+      </div>
+
+      {/* Min/Max labels */}
+      <div className="flex justify-between mt-1 text-xs text-gray-500 dark:text-gray-400">
+        <span>{min}</span>
+        <span>{max}</span>
+      </div>
+    </div>
+  );
+}

--- a/my-app/src/components/SliderRangeDemo.tsx
+++ b/my-app/src/components/SliderRangeDemo.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+import SliderRange from "./SliderRange";
+
+export default function SliderRangeDemo() {
+    const [basicValue, setBasicValue] = useState(50);
+    const [preciseValue, setPreciseValue] = useState(2.5);
+    const [rangeValue, setRangeValue] = useState(75);
+
+    return (
+        <div className="max-w-md mx-auto p-6 space-y-8 bg-white dark:bg-gray-800 rounded-lg shadow-lg">
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 text-center mb-6">
+                Slider Range Examples
+            </h2>
+
+            {/* Basic slider */}
+            <div>
+                <SliderRange
+                    label="Basic Slider"
+                    value={basicValue}
+                    onChange={setBasicValue}
+                    min={0}
+                    max={100}
+                    step={1}
+                />
+            </div>
+
+            {/* Precise slider with decimal steps */}
+            <div>
+                <SliderRange
+                    label="Precise Slider (0.1 steps)"
+                    value={preciseValue}
+                    onChange={setPreciseValue}
+                    min={0}
+                    max={5}
+                    step={0.1}
+                    className="mt-4"
+                />
+            </div>
+
+            {/* Custom range slider */}
+            <div>
+                <SliderRange
+                    label="Custom Range"
+                    value={rangeValue}
+                    onChange={setRangeValue}
+                    min={10}
+                    max={200}
+                    step={5}
+                    className="mt-4"
+                />
+            </div>
+
+            {/* Disabled slider */}
+            <div>
+                <SliderRange
+                    label="Disabled Slider"
+                    value={30}
+                    onChange={() => { }}
+                    min={0}
+                    max={100}
+                    step={1}
+                    disabled={true}
+                    className="mt-4"
+                />
+            </div>
+
+            {/* Slider without value display */}
+            <div>
+                <SliderRange
+                    label="Hidden Value"
+                    value={basicValue}
+                    onChange={setBasicValue}
+                    min={0}
+                    max={100}
+                    step={1}
+                    showValue={false}
+                    className="mt-4"
+                />
+            </div>
+
+            {/* Current values display */}
+            <div className="mt-6 p-4 bg-gray-50 dark:bg-gray-700 rounded-lg">
+                <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-2">Current Values:</h3>
+                <ul className="text-sm text-gray-700 dark:text-gray-300 space-y-1">
+                    <li>Basic: {basicValue}</li>
+                    <li>Precise: {preciseValue}</li>
+                    <li>Custom Range: {rangeValue}</li>
+                </ul>
+            </div>
+        </div>
+    );
+}

--- a/my-app/src/components/input_view/AvoidSection.tsx
+++ b/my-app/src/components/input_view/AvoidSection.tsx
@@ -35,7 +35,7 @@ export default function AvoidSection({ items }: Props) {
       </div>
       {enabled && (
         <>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-col sm:flex-row items-stretch gap-2">
             <SearchableDropdown
               label="Avoid Item"
               placeholder="Select item"
@@ -49,7 +49,7 @@ export default function AvoidSection({ items }: Props) {
               ]}
               value={selected}
               onChange={setSelected}
-              className="flex-grow"
+              className="flex-grow w-full"
             />
             <SimpleButton text="Add" onClick={() => {
               if (selected) {

--- a/my-app/src/components/input_view/InputSection.tsx
+++ b/my-app/src/components/input_view/InputSection.tsx
@@ -26,7 +26,7 @@ export default function InputSection({ heroes, attrTypes, filteredItems, onSubmi
         }}
         className="grid"
       >
-        <div className="flex flex-row gap-4">
+        <div className="flex flex-col sm:flex-row gap-4">
           <HeroSelect heroes={heroes} />
           <CashInput />
         </div>

--- a/my-app/src/components/input_view/InputSection.tsx
+++ b/my-app/src/components/input_view/InputSection.tsx
@@ -26,7 +26,7 @@ export default function InputSection({ heroes, attrTypes, filteredItems, onSubmi
         }}
         className="grid"
       >
-        <div className="flex flex-col sm:flex-row gap-4">
+        <div className="grid gap-4 grid-cols-1 sm:grid-cols-2">
           <HeroSelect heroes={heroes} />
           <CashInput />
         </div>

--- a/my-app/src/components/input_view/MinValueSection.tsx
+++ b/my-app/src/components/input_view/MinValueSection.tsx
@@ -42,14 +42,14 @@ export default function MinValueSection({ attrTypes }: Props) {
         <div className="space-y-4">
           {groups.map((g, idx) => (
             <div key={idx} className="rounded border p-3 space-y-2">
-              <div className="flex items-center gap-2">
+              <div className="flex flex-col sm:flex-row items-center gap-2">
                 <span className="text-sm font-medium dark:text-gray-300">Target Value:</span>
                 <NumberInput
                   value={g.value}
                   onChange={val => dispatch(setMinGroupValue({ index: idx, value: val }))}
                   min={0}
                   label="Minimum Value"
-                  className="w-24"
+                  className="w-full sm:w-24"
                 />
                 {groups.length > 1 && (
                   <button

--- a/my-app/src/components/input_view/WeightsSection.tsx
+++ b/my-app/src/components/input_view/WeightsSection.tsx
@@ -24,14 +24,14 @@ export default function WeightsSection({ attrTypes }: Props) {
       <label className="block text-sm font-medium dark:text-gray-300">Attribute Weights</label>
       <div className="space-y-4 mt-1 mb-4">
         {weights.map((w, idx) => (
-          <div key={idx} className="flex items-center gap-2">
+          <div key={idx} className="flex flex-col sm:flex-row items-center gap-2">
             <SearchableDropdown
               label="Attribute Type"
               placeholder="Select type"
               options={options}
               value={w.type}
               onChange={value => dispatch(setWeightType({ index: idx, type: value }))}
-              className="flex-grow"
+              className="flex-grow w-full"
             />
             <NumberInput
               value={w.weight}
@@ -40,7 +40,7 @@ export default function WeightsSection({ attrTypes }: Props) {
               max={100}
               step={0.01}
               label={`Weight for ${attributeValueToLabel(w.type)}`}
-              className="w-24"
+              className="w-full sm:w-24"
             />
             {weights.length > 1 && (
               <button

--- a/my-app/src/components/input_view/WeightsSection.tsx
+++ b/my-app/src/components/input_view/WeightsSection.tsx
@@ -9,6 +9,8 @@ import { attributeValueToLabel } from '../../utils/attributeUtils';
 import NumberInput from '../shared/NumberInput';
 import SearchableDropdown from '../shared/SearchableDropdown';
 import SimpleButton from '../shared/SimpleButton';
+import SliderRange from '../SliderRange';
+
 
 interface Props {
   attrTypes: string[];
@@ -23,40 +25,72 @@ export default function WeightsSection({ attrTypes }: Props) {
     <div>
       <label className="block text-sm font-medium dark:text-gray-300">Attribute Weights</label>
       <div className="space-y-4 mt-1 mb-4">
-        {weights.map((w, idx) => (
-          <div key={idx} className="flex flex-col sm:flex-row items-center gap-2">
-            <SearchableDropdown
-              label="Attribute Type"
-              placeholder="Select type"
-              options={options}
-              value={w.type}
-              onChange={value => dispatch(setWeightType({ index: idx, type: value }))}
-              className="flex-grow w-full"
-            />
-            <NumberInput
-              value={w.weight}
-              onChange={val => dispatch(setWeightValue({ index: idx, value: val }))}
-              min={0}
-              max={100}
-              step={0.01}
-              label={`Weight for ${attributeValueToLabel(w.type)}`}
-              className="w-full sm:w-24"
-            />
-            {weights.length > 1 && (
-              <button
-                type="button"
-                className="flex-shrink-0 rounded p-2 text-gray-400 dark:text-gray-500 hover:bg-red-50 dark:hover:bg-gray-900 hover:text-red-600 dark:hover:text-red-400"
-                onClick={() => dispatch(removeWeightRow(idx))}
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                </svg>
-              </button>
-            )}
-          </div>
-        ))}
+        {weights.map((w, idx) => {
+          const selectedTypes = weights.map((row, i) => i !== idx ? row.type : null).filter(Boolean);
+          const uniqueOptions = options.filter(opt => !selectedTypes.includes(opt.value) || opt.value === w.type);
+          return (
+            <div key={idx} className="grid">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <div className="w-full">
+                  <SearchableDropdown
+                    label="Attribute Type"
+                    placeholder="Select type"
+                    options={uniqueOptions}
+                    value={w.type}
+                    onChange={value => dispatch(setWeightType({ index: idx, type: value }))}
+                    className="flex-grow w-full"
+                  />
+                </div>
+                <div className="flex flex-col gap-2 w-full sm:w-auto">
+                  <div className="flex flex-row items-center gap-2">
+                    <NumberInput
+                      value={w.weight}
+                      onChange={val => dispatch(setWeightValue({ index: idx, value: val }))}
+                      min={0}
+                      max={100}
+                      step={0.01}
+                      label={`Weight for ${attributeValueToLabel(w.type)}`}
+                      className="w-full sm:w-24"
+                    />
+                    <button
+                      type="button"
+                      className="flex-shrink-0 rounded p-2 text-gray-400 dark:text-gray-500 hover:bg-red-50 dark:hover:bg-gray-900 hover:text-red-600 dark:hover:text-red-400"
+                      onClick={() => dispatch(removeWeightRow(idx))}
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div className="w-full">
+
+                <SliderRange
+                  value={w.weight}
+                  onChange={val => dispatch(setWeightValue({ index: idx, value: val }))}
+                  min={0}
+                  max={1}
+                  step={0.05}
+                  showValue={false}
+                  className="w-full mt-2"
+                />
+              </div>
+            </div>
+
+          );
+        })}
       </div>
-      <SimpleButton onClick={() => dispatch(addWeightRow(attrTypes[0]))} text='Add Row' />
+      <SimpleButton
+        onClick={() => {
+          // Find the first unused attribute type
+          const selectedTypes = weights.map(w => w.type);
+          const firstUnused = attrTypes.find(t => !selectedTypes.includes(t)) || attrTypes[0];
+          dispatch(addWeightRow(firstUnused));
+        }}
+        text='Add Row'
+      />
+
 
     </div>
   );

--- a/my-app/src/components/shared/NumberInput.tsx
+++ b/my-app/src/components/shared/NumberInput.tsx
@@ -44,7 +44,7 @@ export default function NumberInput({
     <div className={`relative inline-block ${className || ''}`}>
       <input
         type="number"
-        className={`block w-full px-3 py-2 text-sm font-medium text-gray-900 dark:text-gray-200 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm transition-colors focus:border-indigo-500 focus:ring-indigo-500 dark:focus:border-indigo-400 dark:focus:ring-indigo-400 placeholder-gray-400 dark:placeholder-gray-500`}
+        className={`block w-full px-3 py-2 text-base font-medium text-gray-900 dark:text-gray-200 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm transition-colors focus:border-indigo-500 focus:ring-indigo-500 dark:focus:border-indigo-400 dark:focus:ring-indigo-400 placeholder-gray-400 dark:placeholder-gray-500`}
         value={inputValue}
         onChange={handleChange}
         inputMode="decimal"

--- a/my-app/src/components/shared/NumberInput.tsx
+++ b/my-app/src/components/shared/NumberInput.tsx
@@ -41,10 +41,10 @@ export default function NumberInput({
   };
 
   return (
-    <div className={`relative inline-block ${className || ''}`}>
+    <div className={`relative ${className || ''}`}>
       <input
         type="number"
-        className={`block w-full px-3 py-2 text-base font-medium text-gray-900 dark:text-gray-200 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm transition-colors focus:border-indigo-500 focus:ring-indigo-500 dark:focus:border-indigo-400 dark:focus:ring-indigo-400 placeholder-gray-400 dark:placeholder-gray-500`}
+        className={`block w-full px-3 py-2 text-base font-medium text-gray-900 dark:text-gray-200 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm transition-colors focus:border-indigo-500 focus:ring-indigo-500 dark:focus:border-indigo-400 dark:focus:ring-indigo-400 placeholder-gray-400 dark:placeholder-gray-500 no-spinner`}
         value={inputValue}
         onChange={handleChange}
         inputMode="decimal"

--- a/my-app/src/components/shared/SearchableDropdown.tsx
+++ b/my-app/src/components/shared/SearchableDropdown.tsx
@@ -81,7 +81,12 @@ export default function SearchableDropdown({ label, options, value, onChange, pl
           }}
           ref={triggerRef}
         >
-          <span style={{ color: displayedColor || 'inherit', minWidth: '135px', display: 'inline-block' }}>{displayedLabel}</span>
+          <span
+            style={{ color: displayedColor || 'inherit' }}
+            className="truncate"
+          >
+            {displayedLabel}
+          </span>
         </button>
         <button
           type="button"
@@ -106,7 +111,7 @@ export default function SearchableDropdown({ label, options, value, onChange, pl
               <input
                 type="text"
                 ref={inputRef}
-                className="mx-3 my-2 w-[calc(100%-1.5rem)] rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-200 px-2 py-1 text-sm placeholder-gray-400 dark:placeholder-gray-500"
+                className="mx-3 my-2 w-[calc(100%-1.5rem)] rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-200 px-2 py-1 text-base placeholder-gray-400 dark:placeholder-gray-500"
                 placeholder="Search..."
                 value={search}
                 onChange={e => setSearch(e.target.value)}

--- a/my-app/src/index.css
+++ b/my-app/src/index.css
@@ -29,3 +29,15 @@ body {
     linear-gradient(black, black) padding-box;
   mask-composite: subtract;
 }
+
+/* Hide number input arrows for Chrome, Safari, Edge */
+.no-spinner::-webkit-outer-spin-button,
+.no-spinner::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* Hide number input arrows for Firefox */
+.no-spinner[type='number'] {
+  -moz-appearance: textfield;
+}


### PR DESCRIPTION
## Summary
- disable iOS zoom by bumping input text size
- truncate dropdown labels and allow wrapping on small screens
- tweak layout so hero/cash inputs stack in mobile view
- wrap avoid, min value and weight rows for mobile
- document mobile layout fix in changelog

## Testing
- `npm test` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684abc9552c0832b819193f7e72d4a91