### PR TITLE
Add import/export modal

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,3 +20,4 @@
 
 2025-06-14  add tests for dropdown, toolbar, and calculator  src/components
 2025-06-15  add import/export modal for state management  src/components/ImportExportModal.tsx
+2025-06-15  fix import modal usability issues and persist equipped toggle  src/components/ImportExportModal.tsx

--- a/changelog.md
+++ b/changelog.md
@@ -19,3 +19,4 @@
 2025-06-12 Fix mobile layout issues and disable iOS input zoom src/components
 
 2025-06-14  add tests for dropdown, toolbar, and calculator  src/components
+2025-06-15  add import/export modal for state management  src/components/ImportExportModal.tsx

--- a/my-app/src/components/ImportExportModal.tsx
+++ b/my-app/src/components/ImportExportModal.tsx
@@ -1,0 +1,103 @@
+import { useState, useRef } from "react";
+import { useAppDispatch, useAppSelector } from "../hooks";
+import { importState } from "../slices/inputSlice";
+import type { InputState } from "../slices/inputSlice";
+
+interface Props {
+  onClose: () => void;
+}
+
+export default function ImportExportModal({ onClose }: Props) {
+  const dispatch = useAppDispatch();
+  const current = useAppSelector((s) => s.input.present);
+  const [text, setText] = useState("");
+  const fileRef = useRef<HTMLInputElement>(null);
+  const onFile = async (f: File) => {
+    setText(await f.text());
+  };
+  const exportFile = () => {
+    const blob = new Blob([JSON.stringify(current, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "state.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+  const confirm = () => {
+    try {
+      const parsed = JSON.parse(text) as InputState;
+      dispatch(importState(parsed));
+      onClose();
+    } catch {
+      // ignore parse errors
+    }
+  };
+  return (
+    <div className="fixed inset-0 z-20 grid place-items-center bg-black/50 p-4">
+      <div className="glass-card relative w-full max-w-2xl space-y-4 rounded-xl bg-white dark:bg-gray-800 p-4">
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-2 top-2 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+        >
+          ×
+        </button>
+        <div className="grid gap-4 md:grid-cols-2">
+          <textarea
+            className="w-full h-40 p-2 border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+            placeholder="Paste JSON here"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+          />
+          <textarea
+            className="w-full h-40 p-2 border border-gray-300 dark:border-gray-700 bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+            readOnly
+            value={JSON.stringify(current, null, 2)}
+          />
+        </div>
+        <div
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={(e) => {
+            e.preventDefault();
+            const file = e.dataTransfer.files[0];
+            if (file) onFile(file);
+          }}
+          className="flex items-center justify-center rounded border-2 border-dashed border-gray-400 p-4 text-sm text-gray-600 dark:text-gray-300"
+        >
+          <input
+            type="file"
+            accept="application/json"
+            ref={fileRef}
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) onFile(f);
+            }}
+            className="hidden"
+          />
+          <button type="button" onClick={() => fileRef.current?.click()}>
+            Drop file or click to upload
+          </button>
+        </div>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={exportFile}
+            className="rounded bg-indigo-600 px-3 py-1 text-white hover:bg-indigo-700"
+          >
+            Export
+          </button>
+          <button
+            type="button"
+            onClick={confirm}
+            className="rounded bg-teal-600 px-3 py-1 text-white hover:bg-teal-700"
+          >
+            Import
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/my-app/src/components/Toolbar.tsx
+++ b/my-app/src/components/Toolbar.tsx
@@ -1,12 +1,14 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { ActionCreators } from "redux-undo";
 import { useAppDispatch, useAppSelector } from "../hooks";
 import HistoryDropdown from "./HistoryDropdown";
+import ImportExportModal from "./ImportExportModal";
 
 export default function Toolbar() {
   const dispatch = useAppDispatch();
   const past = useAppSelector((s) => s.input.past);
   const future = useAppSelector((s) => s.input.future);
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -40,7 +42,15 @@ export default function Toolbar() {
           Redo
         </button>
         <HistoryDropdown history={past} />
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-indigo-700 dark:bg-indigo-700 dark:hover:bg-indigo-800"
+        >
+          Import
+        </button>
       </div>
+      {open && <ImportExportModal onClose={() => setOpen(false)} />}
     </div>
   );
 }

--- a/my-app/src/components/__tests__/Toolbar.test.tsx
+++ b/my-app/src/components/__tests__/Toolbar.test.tsx
@@ -25,16 +25,19 @@ describe("Toolbar", () => {
   });
 
   it("imports state from JSON", () => {
-    const { getByText, getByPlaceholderText, getAllByText } = render(
+    const { getByText, getByLabelText, getAllByText } = render(
       <Provider store={store}>
         <Toolbar />
       </Provider>,
     );
     fireEvent.click(getByText("Import"));
-    fireEvent.change(getByPlaceholderText("Paste JSON here"), {
+    const confirm = getAllByText("Import")[1];
+    expect(confirm).toBeDisabled();
+    fireEvent.change(getByLabelText("Import JSON"), {
       target: { value: JSON.stringify({ ...store.getState().input.present, hero: "Pharah" }) },
     });
-    fireEvent.click(getAllByText("Import")[1]);
+    expect(confirm).not.toBeDisabled();
+    fireEvent.click(confirm);
     expect(store.getState().input.present.hero).toBe("Pharah");
   });
 });

--- a/my-app/src/components/__tests__/Toolbar.test.tsx
+++ b/my-app/src/components/__tests__/Toolbar.test.tsx
@@ -23,4 +23,18 @@ describe("Toolbar", () => {
     expect(spy).toHaveBeenCalledWith(ActionCreators.redo());
     spy.mockRestore();
   });
+
+  it("imports state from JSON", () => {
+    const { getByText, getByPlaceholderText, getAllByText } = render(
+      <Provider store={store}>
+        <Toolbar />
+      </Provider>,
+    );
+    fireEvent.click(getByText("Import"));
+    fireEvent.change(getByPlaceholderText("Paste JSON here"), {
+      target: { value: JSON.stringify({ ...store.getState().input.present, hero: "Pharah" }) },
+    });
+    fireEvent.click(getAllByText("Import")[1]);
+    expect(store.getState().input.present.hero).toBe("Pharah");
+  });
 });

--- a/my-app/src/components/input_view/EquippedSection.tsx
+++ b/my-app/src/components/input_view/EquippedSection.tsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
 import { useAppDispatch, useAppSelector } from "../../hooks";
 import {
   addEquippedSlot,
   removeEquippedSlot,
   setEquipped,
+  toggleEquippedEnabled,
 } from "../../slices/inputSlice";
 import type { Item } from "../../types";
 import { attributeValueToLabel } from "../../utils/attributeUtils";
@@ -18,17 +18,8 @@ interface Props {
 
 export default function EquippedSection({ items }: Props) {
   const equipped = useAppSelector((state) => state.input.present.equipped);
+  const enabled = useAppSelector((s) => s.input.present.equippedEnabled);
   const dispatch = useAppDispatch();
-  const [useEquipped, setUseEquipped] = useState(false);
-
-  const handleToggle = (checked: boolean) => {
-    setUseEquipped(checked);
-    if (!checked) {
-      equipped.forEach((_, idx) =>
-        dispatch(setEquipped({ index: idx, id: "" })),
-      );
-    }
-  };
 
   return (
     <div>
@@ -36,8 +27,8 @@ export default function EquippedSection({ items }: Props) {
         <input
           id="use-equipped-checkbox"
           type="checkbox"
-          checked={useEquipped}
-          onChange={(e) => handleToggle(e.target.checked)}
+          checked={enabled}
+          onChange={() => dispatch(toggleEquippedEnabled())}
           className="h-4 w-4 text-teal-600 border-gray-300 rounded focus:ring-teal-500"
         />
         <label
@@ -47,7 +38,7 @@ export default function EquippedSection({ items }: Props) {
           Use Equipped Items
         </label>
       </div>
-      {useEquipped && (
+      {enabled && (
         <div className="space-y-4 mt-2">
           {equipped.map((id, idx) => (
             <div key={idx} className="flex items-center gap-2">

--- a/my-app/src/components/shared/Dropdown.tsx
+++ b/my-app/src/components/shared/Dropdown.tsx
@@ -26,6 +26,7 @@ export default function Dropdown({ label, options, value, onChange }: Props) {
     <div className="relative" ref={ref}>
       <button
         type="button"
+        aria-label={label}
         onClick={() => setOpen((v) => !v)}
         className="flex items-center gap-1 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-800"
       >

--- a/my-app/src/components/shared/Dropdown.tsx
+++ b/my-app/src/components/shared/Dropdown.tsx
@@ -1,0 +1,61 @@
+import { useState, useRef, useEffect } from "react";
+
+interface Option {
+  value: string;
+  label: string;
+}
+
+interface Props {
+  label: string;
+  options: Option[];
+  value: string;
+  onChange: (v: string) => void;
+}
+
+export default function Dropdown({ label, options, value, onChange }: Props) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-1 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-800"
+      >
+        {value ? options.find((o) => o.value === value)?.label : "Select an option"}
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute z-10 mt-1 w-40 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-lg"
+        >
+          {options.length === 0 ? (
+            <p className="p-2 text-sm text-gray-500 dark:text-gray-400">No options available</p>
+          ) : (
+            <ul>
+              {options.map((o) => (
+                <li
+                  key={o.value}
+                  className="cursor-pointer px-3 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800"
+                  onClick={() => {
+                    onChange(o.value);
+                    setOpen(false);
+                  }}
+                >
+                  {o.label}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/my-app/src/slices/__tests__/inputSlice.test.ts
+++ b/my-app/src/slices/__tests__/inputSlice.test.ts
@@ -13,6 +13,7 @@ import reducer, {
   removeMinGroup,
   addEquippedSlot,
   removeEquippedSlot,
+  importState,
 } from "../inputSlice";
 
 const initialState = reducer(undefined, { type: "init" } as any);
@@ -69,4 +70,15 @@ test("addEquippedSlot and removeEquippedSlot modify equipped array", () => {
   expect(state.equipped).toHaveLength(3);
   state = reducer(state, removeEquippedSlot(2));
   expect(state.equipped).toHaveLength(2);
+});
+
+test("importState replaces entire state", () => {
+  const newState = {
+    ...initialState,
+    hero: "Tracer",
+    cash: 5000,
+  };
+  const state = reducer(initialState, importState(newState));
+  expect(state.hero).toBe("Tracer");
+  expect(state.cash).toBe(5000);
 });

--- a/my-app/src/slices/__tests__/inputSlice.test.ts
+++ b/my-app/src/slices/__tests__/inputSlice.test.ts
@@ -13,6 +13,8 @@ import reducer, {
   removeMinGroup,
   addEquippedSlot,
   removeEquippedSlot,
+  setEquipped,
+  toggleEquippedEnabled,
   importState,
 } from "../inputSlice";
 
@@ -70,6 +72,15 @@ test("addEquippedSlot and removeEquippedSlot modify equipped array", () => {
   expect(state.equipped).toHaveLength(3);
   state = reducer(state, removeEquippedSlot(2));
   expect(state.equipped).toHaveLength(2);
+});
+
+test("toggleEquippedEnabled toggles flag and clears items when disabling", () => {
+  let state = reducer(initialState, toggleEquippedEnabled());
+  expect(state.equippedEnabled).toBe(true);
+  state = reducer(state, setEquipped({ index: 0, id: "item1" }));
+  state = reducer(state, toggleEquippedEnabled());
+  expect(state.equippedEnabled).toBe(false);
+  expect(state.equipped).toEqual(["", ""]);
 });
 
 test("importState replaces entire state", () => {

--- a/my-app/src/slices/inputSlice.ts
+++ b/my-app/src/slices/inputSlice.ts
@@ -65,16 +65,10 @@ const inputSlice = createSlice({
     toggleAvoidEnabled(state) {
       state.avoidEnabled = !state.avoidEnabled;
     },
-    setWeightType(
-      state,
-      action: PayloadAction<{ index: number; type: string }>,
-    ) {
+    setWeightType(state, action: PayloadAction<{ index: number; type: string }>) {
       state.weights[action.payload.index].type = action.payload.type;
     },
-    setWeightValue(
-      state,
-      action: PayloadAction<{ index: number; value: number }>,
-    ) {
+    setWeightValue(state, action: PayloadAction<{ index: number; value: number }>) {
       state.weights[action.payload.index].weight = action.payload.value;
     },
     addWeightRow(state, action: PayloadAction<string>) {
@@ -101,27 +95,21 @@ const inputSlice = createSlice({
     removeMinGroup(state, action: PayloadAction<number>) {
       state.minAttrGroups.splice(action.payload, 1);
     },
-    setMinGroupValue(
-      state,
-      action: PayloadAction<{ index: number; value: number }>,
-    ) {
+    setMinGroupValue(state, action: PayloadAction<{ index: number; value: number }>) {
       state.minAttrGroups[action.payload.index].value = action.payload.value;
     },
-    addAttrToGroup(
-      state,
-      action: PayloadAction<{ index: number; attr: string }>,
-    ) {
+    addAttrToGroup(state, action: PayloadAction<{ index: number; attr: string }>) {
       const group = state.minAttrGroups[action.payload.index];
       if (!group.attrs.includes(action.payload.attr)) {
         group.attrs.push(action.payload.attr);
       }
     },
-    removeAttrFromGroup(
-      state,
-      action: PayloadAction<{ index: number; attr: string }>,
-    ) {
+    removeAttrFromGroup(state, action: PayloadAction<{ index: number; attr: string }>) {
       const group = state.minAttrGroups[action.payload.index];
       group.attrs = group.attrs.filter((a) => a !== action.payload.attr);
+    },
+    importState(_, action: PayloadAction<InputState>) {
+      return action.payload;
     },
   },
 });
@@ -147,6 +135,7 @@ export const {
   removeAttrFromGroup,
   addEquippedSlot,
   removeEquippedSlot,
+  importState,
 } = inputSlice.actions;
 
 export default inputSlice.reducer;

--- a/my-app/src/slices/inputSlice.ts
+++ b/my-app/src/slices/inputSlice.ts
@@ -6,6 +6,7 @@ export interface InputState {
   hero: string;
   cash: number;
   equipped: (string | "")[];
+  equippedEnabled: boolean;
   toBuy: number;
   avoid: string[];
   avoidEnabled: boolean;
@@ -19,6 +20,7 @@ const initialState: InputState = {
   hero: "Ashe",
   cash: 11000,
   equipped: Array(2).fill(""),
+  equippedEnabled: false,
   toBuy: 6,
   avoid: [],
   avoidEnabled: false,
@@ -64,6 +66,12 @@ const inputSlice = createSlice({
     },
     toggleAvoidEnabled(state) {
       state.avoidEnabled = !state.avoidEnabled;
+    },
+    toggleEquippedEnabled(state) {
+      state.equippedEnabled = !state.equippedEnabled;
+      if (!state.equippedEnabled) {
+        state.equipped = Array(2).fill("");
+      }
     },
     setWeightType(state, action: PayloadAction<{ index: number; type: string }>) {
       state.weights[action.payload.index].type = action.payload.type;
@@ -122,6 +130,7 @@ export const {
   addAvoid,
   removeAvoid,
   toggleAvoidEnabled,
+  toggleEquippedEnabled,
   setWeightType,
   setWeightValue,
   addWeightRow,


### PR DESCRIPTION
## Summary
- add Import button with modal in Toolbar
- implement ImportExportModal component for loading/saving state
- support importState in Redux slice and test it
- update Toolbar tests
- add simple Dropdown component to satisfy tests
- document new feature in changelog

## Testing
- `npm --prefix my-app run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_684e6007ef44832bbee041f085f8bb98