### PR TITLE
Add editor override toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,5 @@ Overwatch Tool helps you optimize item builds for your hero in Overwatch.
 - Enabling minimum values now starts with a default group for Health, Armor,
   and Shield totaling 50.
 - Assign weights to attributes to prioritize your optimization.
+- Toggle editor overrides on or off for item attributes.
 - Includes a breakpoint calculator for analyzing damage thresholds.

--- a/changelog.md
+++ b/changelog.md
@@ -23,3 +23,4 @@
 2025-06-15  fix import modal usability issues and persist equipped toggle  src/components/ImportExportModal.tsx
 2025-06-28  fix DFS selection logic for build ranking  src/Optimizer.tsx
 2025-06-30  add All Hero and No Hero options for hero selection  src/components/input_view/HeroSelect.tsx
+2025-06-30  add toggle to enable/disable editor overrides  src/components/input_view/OverrideToggle.tsx

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -4,3 +4,4 @@ Initial memory bank created. No active tasks are in progress.
 Updated `AGENTS.md` to mention the memory bank requirement.
 Future updates should note current work, open issues, and memory bank changes.
 Added hero options for "All Heroes" and "No Hero" in selection dropdown.
+Added UI toggle to enable or disable editor overrides.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -4,3 +4,4 @@
 - Features include search dropdowns, avoid list, import/export, and responsive design.
 - Tests exist for major components and must keep coverage above 80%.
 - Memory bank initialized with project overview and active context.
+- Added toggle for editor overrides in configuration panel.

--- a/my-app/src/components/input_view/InputSection.tsx
+++ b/my-app/src/components/input_view/InputSection.tsx
@@ -3,6 +3,7 @@ import AvoidSection from "./AvoidSection";
 import CashInput from "./CashInput";
 import EquippedSection from "./EquippedSection";
 import HeroSelect from "./HeroSelect";
+import OverrideToggle from "./OverrideToggle";
 import MinValueSection from "./MinValueSection";
 import SubmitSection from "./SubmitSection";
 import WeightsSection from "./WeightsSection";
@@ -15,18 +16,10 @@ interface Props {
   validate: () => boolean;
 }
 
-export default function InputSection({
-  heroes,
-  attrTypes,
-  filteredItems,
-  onSubmit,
-  validate,
-}: Props) {
+export default function InputSection({ heroes, attrTypes, filteredItems, onSubmit, validate }: Props) {
   return (
     <div className="glass-card space-y-6 rounded-xl shadow-lg p-6 sm:p-8  dark:border-gray-700">
-      <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 sm:text-3xl">
-        Configuration
-      </h2>
+      <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 sm:text-3xl">Configuration</h2>
       <form
         onSubmit={(e) => {
           e.preventDefault();
@@ -42,6 +35,9 @@ export default function InputSection({
         <EquippedSection items={filteredItems} />
         <hr className="my-4 border-gray-300 dark:border-gray-600" />
         <AvoidSection items={filteredItems} />
+        <div className="my-4">
+          <OverrideToggle />
+        </div>
         <hr className="my-4 border-gray-300 dark:border-gray-600" />
         <MinValueSection attrTypes={attrTypes} />
         <hr className="my-4 border-gray-300 dark:border-gray-600" />

--- a/my-app/src/components/input_view/OverrideToggle.tsx
+++ b/my-app/src/components/input_view/OverrideToggle.tsx
@@ -1,0 +1,21 @@
+import { useAppDispatch, useAppSelector } from "../../hooks";
+import { toggleUseOverrides } from "../../slices/inputSlice";
+
+export default function OverrideToggle() {
+  const enabled = useAppSelector((s) => s.input.present.useOverrides);
+  const dispatch = useAppDispatch();
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        id="override-toggle"
+        type="checkbox"
+        checked={enabled}
+        onChange={() => dispatch(toggleUseOverrides())}
+        className="h-4 w-4 text-teal-600 border-gray-300 rounded focus:ring-teal-500"
+      />
+      <label htmlFor="override-toggle" className="text-sm dark:text-gray-300 select-none">
+        Enable Editor Overrides
+      </label>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- toggle editor overrides in configuration
- document new functionality
- track progress in memory bank
- note new feature in changelog

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_686258791614832b986030c981187efe