### PR TITLE
feat: add item gallery for local item overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ Overwatch Tool helps you optimize item builds for your hero in Overwatch.
 - Assign weights to attributes to prioritize your optimization.
 - Toggle editor overrides on or off for item attributes.
 - Includes a breakpoint calculator for analyzing damage thresholds.
-- Edit items locally in the Item Gallery with values saved to browser storage.
+- Search and edit items locally in the Item Gallery with values saved to browser storage.

--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ Overwatch Tool helps you optimize item builds for your hero in Overwatch.
 - Assign weights to attributes to prioritize your optimization.
 - Toggle editor overrides on or off for item attributes.
 - Includes a breakpoint calculator for analyzing damage thresholds.
+- Edit items locally in the Item Gallery with values saved to browser storage.

--- a/changelog.md
+++ b/changelog.md
@@ -24,3 +24,4 @@
 2025-06-28  fix DFS selection logic for build ranking  src/Optimizer.tsx
 2025-06-30  add All Hero and No Hero options for hero selection  src/components/input_view/HeroSelect.tsx
 2025-06-30  add toggle to enable/disable editor overrides  src/components/input_view/OverrideToggle.tsx
+2025-06-30  add item gallery for local overrides  src/components/ItemGallery.tsx

--- a/changelog.md
+++ b/changelog.md
@@ -25,3 +25,4 @@
 2025-06-30  add All Hero and No Hero options for hero selection  src/components/input_view/HeroSelect.tsx
 2025-06-30  add toggle to enable/disable editor overrides  src/components/input_view/OverrideToggle.tsx
 2025-06-30  add item gallery for local overrides  src/components/ItemGallery.tsx
+2025-06-30  improve item gallery with search  src/components/ItemGallery.tsx

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -6,3 +6,4 @@ Future updates should note current work, open issues, and memory bank changes.
 Added hero options for "All Heroes" and "No Hero" in selection dropdown.
 Added UI toggle to enable or disable editor overrides.
 Implemented Item Gallery for editing items with local storage.
+Improved Item Gallery with searchable dropdown.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -5,3 +5,4 @@ Updated `AGENTS.md` to mention the memory bank requirement.
 Future updates should note current work, open issues, and memory bank changes.
 Added hero options for "All Heroes" and "No Hero" in selection dropdown.
 Added UI toggle to enable or disable editor overrides.
+Implemented Item Gallery for editing items with local storage.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -6,3 +6,4 @@
 - Memory bank initialized with project overview and active context.
 - Added toggle for editor overrides in configuration panel.
 - Added Item Gallery panel for local item edits.
+- Improved Item Gallery with search functionality.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -5,3 +5,4 @@
 - Tests exist for major components and must keep coverage above 80%.
 - Memory bank initialized with project overview and active context.
 - Added toggle for editor overrides in configuration panel.
+- Added Item Gallery panel for local item edits.

--- a/my-app/src/components/ItemGallery.tsx
+++ b/my-app/src/components/ItemGallery.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { Item } from "../types";
+import SearchableDropdown from "./shared/SearchableDropdown";
 import { loadOverrides, saveOverrides, ItemOverrideEntry } from "../utils/localOverrides";
 
 interface Props {
@@ -10,7 +11,7 @@ export default function ItemGallery({ items }: Props) {
   const [overrides, setOverrides] = useState<Record<string, ItemOverrideEntry>>(
     () => loadOverrides(),
   );
-  const [editing, setEditing] = useState<Record<string, boolean>>({});
+  const [selected, setSelected] = useState<string>("");
 
   const update = (key: string, entry: ItemOverrideEntry) => {
     const next = { ...overrides, [key]: { ...overrides[key], ...entry } };
@@ -39,55 +40,55 @@ export default function ItemGallery({ items }: Props) {
           View JSON
         </button>
       </div>
-      <ul className="max-h-64 overflow-y-auto space-y-2 text-sm">
-        {items.map((it) => {
-          const key = it.id || it.name;
-          const entry = overrides[key] || {};
-          const edit = editing[key];
+      <SearchableDropdown
+        label="Select Item"
+        placeholder="Search items"
+        options={items.map((it) => ({ value: it.id || it.name, label: it.name }))}
+        value={selected}
+        onChange={setSelected}
+        className="w-full"
+      />
+      {selected && (
+        (() => {
+          const it = items.find((x) => (x.id || x.name) === selected);
+          if (!it) return null;
+          const entry = overrides[selected] || {};
           const cost = entry.cost ?? it.cost;
           const attrs = entry.attributes ?? it.attributes;
           return (
-            <li key={key} className="border-b border-gray-300 dark:border-gray-600 pb-2">
-              <div className="flex justify-between items-center">
-                <span>{it.name}</span>
+            <div className="space-y-2 text-sm">
+              <div className="flex items-center justify-between">
+                <h3 className="font-semibold dark:text-gray-200">{it.name}</h3>
                 <button
                   type="button"
-                  className="text-indigo-500 hover:underline text-xs"
-                  onClick={() => setEditing((e) => ({ ...e, [key]: !e[key] }))}
+                  className="text-xs text-red-500 hover:underline"
+                  onClick={() => setSelected("")}
                 >
-                  {edit ? "Done" : "Edit"}
+                  Close
                 </button>
               </div>
-              {edit ? (
-                <div className="mt-1 space-y-1">
-                  <input
-                    type="number"
-                    value={cost}
-                    onChange={(e) => update(key, { cost: Number(e.target.value) })}
-                    className="w-full rounded border-gray-300 dark:border-gray-700 dark:bg-gray-800 p-1"
-                  />
-                  {attrs.map((a, i) => (
-                    <input
-                      key={i}
-                      value={a.value}
-                      onChange={(e) => {
-                        const list = [...attrs];
-                        list[i] = { ...a, value: e.target.value };
-                        update(key, { attributes: list });
-                      }}
-                      className="w-full rounded border-gray-300 dark:border-gray-700 dark:bg-gray-800 p-1"
-                    />
-                  ))}
-                </div>
-              ) : (
-                <div className="text-gray-700 dark:text-gray-300 mt-1">
-                  Cost: {cost}
-                </div>
-              )}
-            </li>
+              <input
+                type="number"
+                value={cost}
+                onChange={(e) => update(selected, { cost: Number(e.target.value) })}
+                className="w-full rounded border-gray-300 dark:border-gray-700 dark:bg-gray-800 p-1"
+              />
+              {attrs.map((a, i) => (
+                <input
+                  key={i}
+                  value={a.value}
+                  onChange={(e) => {
+                    const list = [...attrs];
+                    list[i] = { ...a, value: e.target.value };
+                    update(selected, { attributes: list });
+                  }}
+                  className="w-full rounded border-gray-300 dark:border-gray-700 dark:bg-gray-800 p-1"
+                />
+              ))}
+            </div>
           );
-        })}
-      </ul>
+        })()
+      )}
     </div>
   );
 }

--- a/my-app/src/components/ItemGallery.tsx
+++ b/my-app/src/components/ItemGallery.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import type { Item } from "../types";
+import { loadOverrides, saveOverrides, ItemOverrideEntry } from "../utils/localOverrides";
+
+interface Props {
+  items: Item[];
+}
+
+export default function ItemGallery({ items }: Props) {
+  const [overrides, setOverrides] = useState<Record<string, ItemOverrideEntry>>(
+    () => loadOverrides(),
+  );
+  const [editing, setEditing] = useState<Record<string, boolean>>({});
+
+  const update = (key: string, entry: ItemOverrideEntry) => {
+    const next = { ...overrides, [key]: { ...overrides[key], ...entry } };
+    setOverrides(next);
+    saveOverrides(next);
+  };
+
+  const openJson = () => {
+    const w = window.open("", "json");
+    if (w) {
+      w.document.write(`<pre>${JSON.stringify(overrides, null, 2)}</pre>`);
+    }
+  };
+
+  return (
+    <div className="glass-card p-4 space-y-2 rounded-xl dark:border-gray-700">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-bold text-gray-900 dark:text-gray-100">
+          Item Gallery
+        </h2>
+        <button
+          type="button"
+          onClick={openJson}
+          className="text-sm text-indigo-500 hover:underline"
+        >
+          View JSON
+        </button>
+      </div>
+      <ul className="max-h-64 overflow-y-auto space-y-2 text-sm">
+        {items.map((it) => {
+          const key = it.id || it.name;
+          const entry = overrides[key] || {};
+          const edit = editing[key];
+          const cost = entry.cost ?? it.cost;
+          const attrs = entry.attributes ?? it.attributes;
+          return (
+            <li key={key} className="border-b border-gray-300 dark:border-gray-600 pb-2">
+              <div className="flex justify-between items-center">
+                <span>{it.name}</span>
+                <button
+                  type="button"
+                  className="text-indigo-500 hover:underline text-xs"
+                  onClick={() => setEditing((e) => ({ ...e, [key]: !e[key] }))}
+                >
+                  {edit ? "Done" : "Edit"}
+                </button>
+              </div>
+              {edit ? (
+                <div className="mt-1 space-y-1">
+                  <input
+                    type="number"
+                    value={cost}
+                    onChange={(e) => update(key, { cost: Number(e.target.value) })}
+                    className="w-full rounded border-gray-300 dark:border-gray-700 dark:bg-gray-800 p-1"
+                  />
+                  {attrs.map((a, i) => (
+                    <input
+                      key={i}
+                      value={a.value}
+                      onChange={(e) => {
+                        const list = [...attrs];
+                        list[i] = { ...a, value: e.target.value };
+                        update(key, { attributes: list });
+                      }}
+                      className="w-full rounded border-gray-300 dark:border-gray-700 dark:bg-gray-800 p-1"
+                    />
+                  ))}
+                </div>
+              ) : (
+                <div className="text-gray-700 dark:text-gray-300 mt-1">
+                  Cost: {cost}
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/my-app/src/components/__tests__/ItemGallery.test.tsx
+++ b/my-app/src/components/__tests__/ItemGallery.test.tsx
@@ -1,0 +1,22 @@
+/* @vitest-environment jsdom */
+import "@testing-library/jest-dom";
+import { fireEvent, render } from "@testing-library/react";
+import ItemGallery from "../ItemGallery";
+import type { Item } from "../../types";
+import { STORAGE_KEY } from "../../utils/localOverrides";
+
+beforeEach(() => localStorage.clear());
+
+const items: Item[] = [
+  { id: "1", name: "Sword", cost: 100, tab: "weapon", rarity: "common", attributes: [] },
+];
+
+test("edits item and saves to storage", () => {
+  const { getByText, getByDisplayValue } = render(<ItemGallery items={items} />);
+  fireEvent.click(getByText("Edit"));
+  const input = getByDisplayValue("100");
+  fireEvent.change(input, { target: { value: "150" } });
+  fireEvent.click(getByText("Done"));
+  const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+  expect(stored["1"].cost).toBe(150);
+});

--- a/my-app/src/components/__tests__/ItemGallery.test.tsx
+++ b/my-app/src/components/__tests__/ItemGallery.test.tsx
@@ -12,11 +12,15 @@ const items: Item[] = [
 ];
 
 test("edits item and saves to storage", () => {
-  const { getByText, getByDisplayValue } = render(<ItemGallery items={items} />);
-  fireEvent.click(getByText("Edit"));
+  const { getAllByRole, getByPlaceholderText, getByDisplayValue } = render(
+    <ItemGallery items={items} />,
+  );
+  fireEvent.click(getAllByRole("button")[1]);
+  const search = getByPlaceholderText("Search...");
+  fireEvent.change(search, { target: { value: "Sword" } });
+  fireEvent.keyDown(search, { key: "Enter" });
   const input = getByDisplayValue("100");
   fireEvent.change(input, { target: { value: "150" } });
-  fireEvent.click(getByText("Done"));
   const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
   expect(stored["1"].cost).toBe(150);
 });

--- a/my-app/src/utils/__tests__/localOverrides.test.ts
+++ b/my-app/src/utils/__tests__/localOverrides.test.ts
@@ -1,0 +1,16 @@
+/* @vitest-environment jsdom */
+import { loadOverrides, saveOverrides, STORAGE_KEY } from "../localOverrides";
+
+beforeEach(() => localStorage.clear());
+
+test("saveOverrides stores data", () => {
+  saveOverrides({ A: { cost: 1 } });
+  expect(localStorage.getItem(STORAGE_KEY)).toBe(
+    JSON.stringify({ A: { cost: 1 } })
+  );
+});
+
+test("loadOverrides retrieves data", () => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify({ B: { cost: 2 } }));
+  expect(loadOverrides()).toEqual({ B: { cost: 2 } });
+});

--- a/my-app/src/utils/localOverrides.ts
+++ b/my-app/src/utils/localOverrides.ts
@@ -1,0 +1,21 @@
+export const STORAGE_KEY = "itemOverrides";
+
+export interface ItemOverrideEntry {
+  cost?: number;
+  attributes?: { type: string; value: string }[];
+}
+
+export function loadOverrides(): Record<string, ItemOverrideEntry> {
+  if (typeof localStorage === "undefined") return {};
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as Record<string, ItemOverrideEntry>) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function saveOverrides(overrides: Record<string, ItemOverrideEntry>) {
+  if (typeof localStorage === "undefined") return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(overrides));
+}


### PR DESCRIPTION
## Summary
- implement localOverrides utils for LocalStorage
- create ItemGallery component to edit items
- display gallery in Optimizer
- document feature in README and changelog
- update memory bank
- add unit tests for new utils and component

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68626499b014832bba5b02f4b5a1a643