### PR TITLE
Add card-based ItemGallery

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,3 +24,5 @@
 2025-06-28  fix DFS selection logic for build ranking  src/Optimizer.tsx
 2025-06-30  add All Hero and No Hero options for hero selection  src/components/input_view/HeroSelect.tsx
 2025-06-30  add toggle to enable/disable editor overrides  src/components/input_view/OverrideToggle.tsx
+
+2025-06-30  add ItemGallery grid with attribute editor  src/components/ItemGallery.tsx

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -5,3 +5,5 @@ Updated `AGENTS.md` to mention the memory bank requirement.
 Future updates should note current work, open issues, and memory bank changes.
 Added hero options for "All Heroes" and "No Hero" in selection dropdown.
 Added UI toggle to enable or disable editor overrides.
+
+Implemented ItemGallery with ItemCard grid and attribute editor.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -5,3 +5,5 @@
 - Tests exist for major components and must keep coverage above 80%.
 - Memory bank initialized with project overview and active context.
 - Added toggle for editor overrides in configuration panel.
+
+- Implemented ItemGallery with card layout and tests.

--- a/my-app/src/components/ItemGallery.tsx
+++ b/my-app/src/components/ItemGallery.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import type { Item } from "../types";
+import { attributeValueToLabel } from "../utils/attributeUtils";
+import { iconUrlForName } from "../utils/item";
+import { rarityColor } from "../utils/utils";
+import ItemCard from "./shared/ItemCard";
+
+interface Props {
+  items: Item[];
+}
+
+function AttributeEditor({ item }: { item: Item }) {
+  return (
+    <div data-testid="editor" className="p-2 space-y-2 border rounded">
+      {item.attributes.map((a, idx) => (
+        <div key={idx} className="flex items-center gap-2">
+          <span className="w-32 text-sm">{attributeValueToLabel(a.type)}</span>
+          <input
+            className="flex-grow rounded border border-gray-300 p-1 text-sm dark:bg-gray-800"
+            defaultValue={a.value}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function ItemGallery({ items }: Props) {
+  const [openId, setOpenId] = useState<string | null>(null);
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {items.map((it) => (
+        <div key={it.id || it.name} className="space-y-2">
+          <ItemCard
+            title={it.name}
+            subtitle={it.tab}
+            rarity={it.rarity}
+            iconUrl={iconUrlForName(it.name)}
+            content={it.attributes.map((a) => ({
+              text: `<strong>${a.value}</strong> <span class='text-[#8fa6d7] text-sm'>${attributeValueToLabel(a.type)}</span>`,
+            }))}
+            price={`${it.cost} G`}
+          />
+          <button
+            type="button"
+            className="rounded bg-indigo-600 px-2 py-1 text-xs text-white"
+            style={{ backgroundColor: rarityColor(it.rarity) }}
+            onClick={() => setOpenId(openId === (it.id || it.name) ? null : it.id || it.name)}
+          >
+            Edit
+          </button>
+          {openId === (it.id || it.name) && <AttributeEditor item={it} />}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/my-app/src/components/__tests__/ItemGallery.test.tsx
+++ b/my-app/src/components/__tests__/ItemGallery.test.tsx
@@ -1,0 +1,27 @@
+/* @vitest-environment jsdom */
+import "@testing-library/jest-dom";
+import { fireEvent, render } from "@testing-library/react";
+import ItemGallery from "../ItemGallery";
+import type { Item } from "../../types";
+
+describe("ItemGallery", () => {
+  const items: Item[] = [
+    { id: "1", name: "Sword", cost: 100, tab: "weapon", rarity: "common", attributes: [] },
+    { id: "2", name: "Shield", cost: 50, tab: "survival", rarity: "rare", attributes: [] },
+  ];
+
+  it("shows items as cards", () => {
+    const { getByText } = render(<ItemGallery items={items} />);
+    expect(getByText("Sword")).toBeInTheDocument();
+    expect(getByText("Shield")).toBeInTheDocument();
+  });
+
+  it("toggles attribute editor", () => {
+    const { getAllByText, queryByTestId } = render(<ItemGallery items={items} />);
+    const btn = getAllByText("Edit")[0];
+    fireEvent.click(btn);
+    expect(queryByTestId("editor")).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(queryByTestId("editor")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add new `ItemGallery` component that displays items in a grid of `ItemCard`s
- show an inline attribute editor when "Edit" is clicked
- test ItemGallery behaviour
- document update in changelog
- record progress in memory bank

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_686275904000832bb5c3759b9df29e46