### PR TITLE
Move tooltip into global redux store

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -28,3 +28,4 @@
 2025-07-01  create ItemGallery component for browsing items  src/components/ItemGallery.tsx
 2025-07-01  integrate ItemGallery into Optimizer view  src/Optimizer.tsx
 2025-07-01  enhance ItemGallery with search, tooltip preview, folding, scroll  src/components/ItemGallery.tsx
+2025-07-02  move tooltip to redux store  src/slices/tooltipSlice.ts

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -9,3 +9,4 @@ Added ItemGallery into main optimizer layout.
 Implemented hover tooltip, search filter, folding, and scrolling for gallery.
 Implemented hoverable item overview grid and radio-based build selection in Results section.
 
+Moved tooltip state to Redux for global usage.

--- a/my-app/src/App.tsx
+++ b/my-app/src/App.tsx
@@ -1,4 +1,5 @@
 import Optimizer from "./Optimizer";
+import Tooltip from "./components/shared/Tooltip";
 
 function App() {
   return (
@@ -7,6 +8,7 @@ function App() {
         <div className="mx-auto grid gap-6 h-full overflow-y-auto">
           <Optimizer />
         </div>
+        <Tooltip />
       </div>
     </div>
   );

--- a/my-app/src/Optimizer.tsx
+++ b/my-app/src/Optimizer.tsx
@@ -23,7 +23,7 @@ export default function Optimizer() {
   const state = useAppSelector((s) => s.input.present);
   const { hero, cash, equipped, toBuy, avoid, avoidEnabled, weights, minValueEnabled, minAttrGroups, useOverrides } =
     state;
-  const [results, setResults] = useState<ResultCombo | null>(null);
+  const [, setResults] = useState<ResultCombo | null>(null);
   const [builds, setBuilds] = useState<ResultCombo[]>([]);
   const [buildIndex, setBuildIndex] = useState(0);
   // Memoize expensive calculations

--- a/my-app/src/components/ItemGallery.tsx
+++ b/my-app/src/components/ItemGallery.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
+import { useAppDispatch } from "../hooks";
+import { setTooltip, clearTooltip } from "../slices/tooltipSlice";
 import type { Item } from "../types";
 import { attributeValueToLabel } from "../utils/attributeUtils";
-import { getTooltipStyle } from "../utils/tooltipUtils";
 import { rarityColor } from "../utils/utils";
 import ItemCard from "./shared/ItemCard";
 import SearchableDropdown from "./shared/SearchableDropdown";
@@ -12,49 +13,19 @@ interface Props {
 
 export default function ItemGallery({ items }: Props) {
   const [selected, setSelected] = useState(items[0]);
-  const [hovered, setHovered] = useState<Item | null>(null);
-  const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
   const [editMode, setEditMode] = useState(false);
   const [folded, setFolded] = useState(false);
   const [search, setSearch] = useState("");
+  const dispatch = useAppDispatch();
 
   const filtered = items.filter((it) =>
     it.name.toLowerCase().includes(search.toLowerCase()),
   );
 
-  // Tooltip size estimate
-  const TOOLTIP_HEIGHT = 180;
-  const TOOLTIP_WIDTH = 320;
-  const OFFSET = 12;
-
   return (
     <div className="glass-card space-y-6 rounded-xl shadow-lg p-6 sm:p-8  dark:border-gray-700">
       <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 sm:text-3xl">Configuration</h2>
       <div className="relative">
-        {hovered && pos && (
-          <div
-            style={getTooltipStyle(pos.x, pos.y, {
-              width: TOOLTIP_WIDTH,
-              height: TOOLTIP_HEIGHT,
-              offset: OFFSET,
-            })}
-            className="shadow-lg rounded-lg bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700"
-          >
-            <ItemCard
-              title={hovered.name}
-              subtitle={hovered.tab}
-              rarity={hovered.rarity}
-              iconUrl={hovered.iconUrl}
-              content={hovered.attributes.map((a) => ({
-                text: `<strong>${a.value}</strong> <span class='font-sm text-[#8fa6d7]'>${attributeValueToLabel(
-                  a.type,
-                )}</span>`,
-              }))}
-              price={`${hovered.cost} G`}
-              width={320}
-            />
-          </div>
-        )}
         <div>
           {selected && (
             <ItemCard
@@ -112,15 +83,17 @@ export default function ItemGallery({ items }: Props) {
                   key={idx}
                   type="button"
                   onClick={() => setSelected(it)}
-                  onMouseEnter={(e) => {
-                    setHovered(it);
-                    setPos({ x: e.clientX, y: e.clientY });
-                  }}
-                  onMouseMove={(e) => setPos({ x: e.clientX, y: e.clientY })}
-                  onMouseLeave={() => {
-                    // setHovered(null);
-                    // setPos(null);
-                  }}
+                  onMouseEnter={(e) =>
+                    dispatch(
+                      setTooltip({ item: it, x: e.clientX, y: e.clientY }),
+                    )
+                  }
+                  onMouseMove={(e) =>
+                    dispatch(
+                      setTooltip({ item: it, x: e.clientX, y: e.clientY }),
+                    )
+                  }
+                  onMouseLeave={() => dispatch(clearTooltip())}
                   className="flex flex-col items-center gap-1 p-2 rounded border dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800"
                 >
                   {it.iconUrl ? (

--- a/my-app/src/components/__tests__/ItemGallery.test.tsx
+++ b/my-app/src/components/__tests__/ItemGallery.test.tsx
@@ -1,7 +1,9 @@
 /* @vitest-environment jsdom */
 import "@testing-library/jest-dom";
 import { fireEvent, render } from "@testing-library/react";
+import { Provider } from "react-redux";
 import ItemGallery from "../ItemGallery";
+import store from "../../store";
 import type { Item } from "../../types";
 
 const items: Item[] = [
@@ -11,28 +13,43 @@ const items: Item[] = [
 
 describe("ItemGallery", () => {
   it("changes selected item on click", () => {
-    const { getByText } = render(<ItemGallery items={items} />);
+    const { getByText } = render(
+      <Provider store={store}>
+        <ItemGallery items={items} />
+      </Provider>,
+    );
     fireEvent.click(getByText("Two"));
     expect(getByText("ability")).toBeInTheDocument();
   });
 
   it("shows preview on hover", () => {
-    const { getAllByText } = render(<ItemGallery items={items} />);
+    const { getAllByText } = render(
+      <Provider store={store}>
+        <ItemGallery items={items} />
+      </Provider>,
+    );
     const icon = getAllByText("Two")[0];
     fireEvent.mouseOver(icon, { clientX: 20, clientY: 30 });
-    expect(getAllByText("ability").length).toBeGreaterThan(0);
+    const state = store.getState();
+    expect(state.tooltip?.item.name).toBe("Two");
     fireEvent.mouseLeave(icon);
   });
 
   it("toggles edit mode", () => {
-    const { getByText } = render(<ItemGallery items={items} />);
+    const { getByText } = render(
+      <Provider store={store}>
+        <ItemGallery items={items} />
+      </Provider>,
+    );
     fireEvent.click(getByText("Customize"));
     expect(getByText("Edit mode enabled")).toBeInTheDocument();
   });
 
   it("filters and folds gallery", () => {
     const { getByText, queryByRole, getAllByRole, getByPlaceholderText, getAllByText } = render(
-      <ItemGallery items={items} />,
+      <Provider store={store}>
+        <ItemGallery items={items} />
+      </Provider>,
     );
     fireEvent.click(getByText("Hide"));
     expect(queryByRole("button", { name: "Two" })).not.toBeInTheDocument();

--- a/my-app/src/components/input_view/HeroSelect.tsx
+++ b/my-app/src/components/input_view/HeroSelect.tsx
@@ -1,5 +1,6 @@
 import { useAppDispatch, useAppSelector } from "../../hooks";
 import { setHero } from "../../slices/inputSlice";
+import { ALL_HEROES, NO_HERO } from "../../types";
 import SearchableDropdown from "../shared/SearchableDropdown";
 
 interface Props {
@@ -9,6 +10,7 @@ interface Props {
 export default function HeroSelect({ heroes }: Props) {
   const hero = useAppSelector((state) => state.input.present.hero);
   const dispatch = useAppDispatch();
+  const options = [NO_HERO, ALL_HEROES, ...heroes].map((h) => ({ value: h, label: h }));
   return (
     <div>
       <label
@@ -17,13 +19,13 @@ export default function HeroSelect({ heroes }: Props) {
       >
         Hero
       </label>
-      <SearchableDropdown
-        label="Hero"
-        placeholder="Select hero"
-        options={heroes.map((h) => ({ value: h, label: h }))}
-        value={hero}
-        onChange={(v) => dispatch(setHero(v))}
-      />
+        <SearchableDropdown
+          label="Hero"
+          placeholder="Select hero"
+          options={options}
+          value={hero}
+          onChange={(v) => dispatch(setHero(v))}
+        />
     </div>
   );
 }

--- a/my-app/src/components/results_view/ItemsOverviewTable.tsx
+++ b/my-app/src/components/results_view/ItemsOverviewTable.tsx
@@ -1,9 +1,8 @@
-import { useState } from "react";
+import { useAppDispatch } from "../../hooks";
+import { setTooltip, clearTooltip } from "../../slices/tooltipSlice";
 import type { Item } from "../../types";
 import { sortItemsOverview } from "../../utils/item";
-import { getTooltipStyle } from "../../utils/tooltipUtils";
 import { rarityColor } from "../../utils/utils";
-import ItemCard from "../shared/ItemCard";
 
 interface Props {
   eqItems: Item[];
@@ -13,39 +12,10 @@ interface Props {
 
 export default function ItemsOverviewTable({ eqItems, resultItems, showHeader = true }: Props) {
   const allItems = [...eqItems, ...resultItems].sort(sortItemsOverview);
-
-  const [hover, setHover] = useState<{
-    item: Item;
-    x: number;
-    y: number;
-  } | null>(null);
-
-  const TOOLTIP_HEIGHT = 180;
-  const TOOLTIP_WIDTH = 320;
-  const OFFSET = 12;
+  const dispatch = useAppDispatch();
 
   return (
     <div className="relative">
-      {hover && (
-        <div
-          style={getTooltipStyle(hover.x, hover.y, {
-            width: TOOLTIP_WIDTH,
-            height: TOOLTIP_HEIGHT,
-            offset: OFFSET,
-          })}
-          className="transform-none shadow-lg rounded-lg bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700"
-        >
-          <ItemCard
-            title={hover.item.name}
-            subtitle={hover.item.tab}
-            rarity={hover.item.rarity}
-            iconUrl={hover.item.iconUrl}
-            content={hover.item.attributes.map((a) => ({ text: a.value }))}
-            price={hover.item.cost}
-            width={320}
-          />
-        </div>
-      )}
       {showHeader && (
         <h3 className="mb-2 text-lg font-bold text-gray-900 dark:text-gray-200">Items Overview</h3>
       )}
@@ -57,9 +27,13 @@ export default function ItemsOverviewTable({ eqItems, resultItems, showHeader = 
               key={idx}
               className="flex items-center border border-gray-200 dark:border-gray-700 p-1"
               style={{ color: it ? rarityColor(it.rarity) : undefined }}
-              onMouseEnter={(e) => it && setHover({ item: it, x: e.clientX, y: e.clientY })}
-              onMouseMove={(e) => it && setHover({ item: it, x: e.clientX, y: e.clientY })}
-            // onMouseLeave={() => setHover(null)}
+              onMouseEnter={(e) =>
+                it && dispatch(setTooltip({ item: it, x: e.clientX, y: e.clientY }))
+              }
+              onMouseMove={(e) =>
+                it && dispatch(setTooltip({ item: it, x: e.clientX, y: e.clientY }))
+              }
+              onMouseLeave={() => dispatch(clearTooltip())}
             >
               {it && (
                 <>

--- a/my-app/src/components/shared/Tooltip.tsx
+++ b/my-app/src/components/shared/Tooltip.tsx
@@ -1,0 +1,32 @@
+import { useAppSelector } from "../../hooks";
+import ItemCard from "./ItemCard";
+import { getTooltipStyle } from "../../utils/tooltipUtils";
+import { attributeValueToLabel } from "../../utils/attributeUtils";
+
+const TOOLTIP_HEIGHT = 180;
+const TOOLTIP_WIDTH = 320;
+const OFFSET = 12;
+
+export default function Tooltip() {
+  const tooltip = useAppSelector((s) => s.tooltip);
+  if (!tooltip) return null;
+  const { item, x, y } = tooltip;
+  return (
+    <div
+      style={getTooltipStyle(x, y, { width: TOOLTIP_WIDTH, height: TOOLTIP_HEIGHT, offset: OFFSET })}
+      className="shadow-lg rounded-lg bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700"
+    >
+      <ItemCard
+        title={item.name}
+        subtitle={item.tab}
+        rarity={item.rarity}
+        iconUrl={item.iconUrl}
+        content={item.attributes.map((a) => ({
+          text: `<strong>${a.value}</strong> <span class='font-sm text-[#8fa6d7]'>${attributeValueToLabel(a.type)}</span>`,
+        }))}
+        price={`${item.cost} G`}
+        width={320}
+      />
+    </div>
+  );
+}

--- a/my-app/src/slices/tooltipSlice.ts
+++ b/my-app/src/slices/tooltipSlice.ts
@@ -1,0 +1,19 @@
+import { createAction, createReducer } from "@reduxjs/toolkit";
+import type { Item } from "../types";
+
+export interface TooltipState {
+  item: Item;
+  x: number;
+  y: number;
+}
+
+export const setTooltip = createAction<TooltipState>("tooltip/set");
+export const clearTooltip = createAction("tooltip/clear");
+
+const tooltipReducer = createReducer<TooltipState | null>(null, (builder) => {
+  builder
+    .addCase(setTooltip, (_, action) => action.payload)
+    .addCase(clearTooltip, () => null);
+});
+
+export default tooltipReducer;

--- a/my-app/src/store.ts
+++ b/my-app/src/store.ts
@@ -1,10 +1,12 @@
 import { configureStore } from "@reduxjs/toolkit";
 import undoable from "redux-undo";
 import inputReducer from "./slices/inputSlice";
+import tooltipReducer from "./slices/tooltipSlice";
 
 const store = configureStore({
   reducer: {
     input: undoable(inputReducer),
+    tooltip: tooltipReducer,
   },
 });
 


### PR DESCRIPTION
## Summary
- centralize tooltip state with a new redux slice
- show the tooltip from a global component
- update gallery and overview table to use redux actions
- expose tooltip at the top level of the app
- update tests for new tooltip behaviour
- keep hero dropdown options for special heroes
- document the change

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6864dd02f0ec832b90c4aa3296af40b5