### PR TITLE
Refactor item lists into reusable components

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,3 +29,4 @@
 2025-07-01  integrate ItemGallery into Optimizer view  src/Optimizer.tsx
 2025-07-01  enhance ItemGallery with search, tooltip preview, folding, scroll  src/components/ItemGallery.tsx
 2025-07-02  move tooltip to redux store  src/slices/tooltipSlice.ts
+2025-07-02  refactor item tables into reusable components  src/components

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -10,3 +10,4 @@ Implemented hover tooltip, search filter, folding, and scrolling for gallery.
 Implemented hoverable item overview grid and radio-based build selection in Results section.
 
 Moved tooltip state to Redux for global usage.
+Refactored item lists into reusable ItemCardList and BuildList components.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -8,3 +8,4 @@
 - Integrated ItemGallery component into Optimizer view for browsing items.
 - Enhanced ItemGallery with search, hover tooltip, fold button, and scrollable grid.
 - Implemented hoverable item overview grid and selectable build list.
+- Refactored item lists into reusable components.

--- a/my-app/src/components/__tests__/BuildList.test.tsx
+++ b/my-app/src/components/__tests__/BuildList.test.tsx
@@ -1,0 +1,27 @@
+/* @vitest-environment jsdom */
+import "@testing-library/jest-dom";
+import { fireEvent, render } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { vi } from "vitest";
+import BuildList from "../results_view/BuildList";
+import store from "../../store";
+import type { Item, ResultCombo } from "../../types";
+
+const eqItems: Item[] = [];
+const builds: ResultCombo[] = [
+  { cost: 10, score: 0, items: [], breakdown: [] },
+  { cost: 20, score: 0, items: [], breakdown: [] },
+];
+
+describe("BuildList", () => {
+  it("renders builds and handles selection", () => {
+    const onSelect = vi.fn();
+    const { getByLabelText } = render(
+      <Provider store={store}>
+        <BuildList eqItems={eqItems} builds={builds} selected={0} onSelect={onSelect} />
+      </Provider>,
+    );
+    fireEvent.click(getByLabelText("Cost: 20"));
+    expect(onSelect).toHaveBeenCalledWith(1);
+  });
+});

--- a/my-app/src/components/__tests__/ItemCardList.test.tsx
+++ b/my-app/src/components/__tests__/ItemCardList.test.tsx
@@ -1,0 +1,22 @@
+/* @vitest-environment jsdom */
+import "@testing-library/jest-dom";
+import { fireEvent, render } from "@testing-library/react";
+import { vi } from "vitest";
+import ItemCardList from "../shared/ItemCardList";
+import type { Item } from "../../types";
+
+const items: Item[] = [
+  { id: "1", name: "B", cost: 20, tab: "weapon", rarity: "common", attributes: [] },
+  { id: "2", name: "A", cost: 10, tab: "weapon", rarity: "common", attributes: [] },
+];
+
+describe("ItemCardList", () => {
+  it("sorts items and calls onAvoid", () => {
+    const onAvoid = vi.fn();
+    const { getByLabelText, container } = render(<ItemCardList items={items} onAvoid={onAvoid} />);
+    const firstCard = container.querySelector("li:nth-child(1)");
+    expect(firstCard?.textContent).toContain("A");
+    fireEvent.click(getByLabelText("Avoid A"));
+    expect(onAvoid).toHaveBeenCalledWith(items[1]);
+  });
+});

--- a/my-app/src/components/results_view/AllBuilds.tsx
+++ b/my-app/src/components/results_view/AllBuilds.tsx
@@ -1,5 +1,5 @@
 import type { Item, ResultCombo } from "../../types";
-import ItemsOverviewTable from "./ItemsOverviewTable";
+import BuildList from "./BuildList";
 
 interface Props {
   eqItems: Item[];
@@ -10,31 +10,10 @@ interface Props {
 
 export default function AllBuilds({ eqItems, builds, selected, onSelect }: Props) {
   if (builds.length === 0) return null;
-
-  const sorted = builds
-    .map((b, idx) => ({ build: b, idx }))
-    .sort((a, b) => a.build.cost - b.build.cost || b.build.items.length - a.build.items.length);
-
   return (
     <div>
       <h3 className="text-lg font-bold text-gray-900 dark:text-gray-200">All Possible Builds</h3>
-      <ul className="mt-2 space-y-4 max-h-64 overflow-y-auto rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 p-3">
-        {sorted.map(({ build, idx }) => (
-          <li key={idx} className="space-y-2">
-            <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
-              <input
-                type="radio"
-                name="build"
-                checked={idx === selected}
-                onChange={() => onSelect(idx)}
-                className="mr-2"
-              />
-              Cost: {build.cost}
-            </label>
-            <ItemsOverviewTable eqItems={eqItems} resultItems={build.items} showHeader={false} />
-          </li>
-        ))}
-      </ul>
+      <BuildList eqItems={eqItems} builds={builds} selected={selected} onSelect={onSelect} />
     </div>
   );
 }

--- a/my-app/src/components/results_view/BuildList.tsx
+++ b/my-app/src/components/results_view/BuildList.tsx
@@ -1,0 +1,35 @@
+import type { Item, ResultCombo } from "../../types";
+import ItemsOverviewTable from "./ItemsOverviewTable";
+
+interface Props {
+  eqItems: Item[];
+  builds: ResultCombo[];
+  selected: number;
+  onSelect: (idx: number) => void;
+}
+
+export default function BuildList({ eqItems, builds, selected, onSelect }: Props) {
+  if (builds.length === 0) return null;
+  const sorted = builds
+    .map((b, idx) => ({ build: b, idx }))
+    .sort((a, b) => a.build.cost - b.build.cost || b.build.items.length - a.build.items.length);
+  return (
+    <ul className="mt-2 space-y-4 max-h-64 overflow-y-auto rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 p-3">
+      {sorted.map(({ build, idx }) => (
+        <li key={idx} className="space-y-2">
+          <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+            <input
+              type="radio"
+              name="build"
+              checked={idx === selected}
+              onChange={() => onSelect(idx)}
+              className="mr-2"
+            />
+            Cost: {build.cost}
+          </label>
+          <ItemsOverviewTable eqItems={eqItems} resultItems={build.items} showHeader={false} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/my-app/src/components/results_view/FinalBuildList.tsx
+++ b/my-app/src/components/results_view/FinalBuildList.tsx
@@ -1,9 +1,7 @@
 import { useAppDispatch, useAppSelector } from "../../hooks";
 import { addAvoid, toggleAvoidEnabled } from "../../slices/inputSlice";
 import type { Item } from "../../types";
-import { attributeValueToLabel } from "../../utils/attributeUtils";
-import { sortItemsOverview } from "../../utils/item";
-import ItemCard from "../shared/ItemCard";
+import ItemCardList from "../shared/ItemCardList";
 
 interface Props {
   eqItems: Item[];
@@ -14,42 +12,18 @@ export default function FinalBuildList({ eqItems, resultItems }: Props) {
   const dispatch = useAppDispatch();
   const avoidEnabled = useAppSelector((state) => state.input.present.avoidEnabled);
 
-  const sortedItems = [...eqItems, ...resultItems].sort(sortItemsOverview);
+  const items = [...eqItems, ...resultItems];
 
   return (
     <div>
       <h3 className="text-lg font-bold text-gray-900 dark:text-gray-200">Final Build</h3>
-      <ul className="mt-2 space-y-3 max-h-fit overflow-y-auto pr-2">
-        {sortedItems.map((it) => (
-          <li key={it.id}>
-            <ItemCard
-              title={it.name}
-              subtitle={it.tab}
-              rarity={it.rarity}
-              iconUrl={it.iconUrl}
-              content={it.attributes.map((a) =>
-                a.type === "description"
-                  ? {
-                      text: `<span class='font-sm text-[#8fa6d7]'>${a.value}</span>`,
-                    }
-                  : a.type === "Editor's Note"
-                    ? {
-                        text: `<strong>Editor's Note: </strong><br /><span class='font-sm text-[#8fa6d7]'>${a.value}</span>`,
-                      }
-                    : {
-                        text: `<strong>${a.value}</strong> <span class='font-sm text-[#8fa6d7]'>${attributeValueToLabel(a.type)}</span>`,
-                      },
-              )}
-              price={`${it.cost} G`}
-              showAvoidButton
-              onAvoid={() => {
-                if (!avoidEnabled) dispatch(toggleAvoidEnabled());
-                dispatch(addAvoid(it.id || it.name));
-              }}
-            />
-          </li>
-        ))}
-      </ul>
+      <ItemCardList
+        items={items}
+        onAvoid={(it) => {
+          if (!avoidEnabled) dispatch(toggleAvoidEnabled());
+          dispatch(addAvoid(it.id || it.name));
+        }}
+      />
     </div>
   );
 }

--- a/my-app/src/components/shared/ItemCardList.tsx
+++ b/my-app/src/components/shared/ItemCardList.tsx
@@ -1,0 +1,37 @@
+import type { Item } from "../../types";
+import { attributeValueToLabel } from "../../utils/attributeUtils";
+import { sortItemsOverview } from "../../utils/item";
+import ItemCard from "./ItemCard";
+
+interface Props {
+  items: Item[];
+  onAvoid?: (item: Item) => void;
+}
+
+export default function ItemCardList({ items, onAvoid }: Props) {
+  const sorted = [...items].sort(sortItemsOverview);
+  return (
+    <ul className="mt-2 space-y-3 max-h-fit overflow-y-auto pr-2">
+      {sorted.map((it) => (
+        <li key={it.id}>
+          <ItemCard
+            title={it.name}
+            subtitle={it.tab}
+            rarity={it.rarity}
+            iconUrl={it.iconUrl}
+            content={it.attributes.map((a) =>
+              a.type === "description"
+                ? { text: `<span class='font-sm text-[#8fa6d7]'>${a.value}</span>` }
+                : a.type === "Editor's Note"
+                  ? { text: `<strong>Editor's Note: </strong><br /><span class='font-sm text-[#8fa6d7]'>${a.value}</span>` }
+                  : { text: `<strong>${a.value}</strong> <span class='font-sm text-[#8fa6d7]'>${attributeValueToLabel(a.type)}</span>` }
+            )}
+            price={`${it.cost} G`}
+            showAvoidButton={!!onAvoid}
+            onAvoid={() => onAvoid?.(it)}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary
- share ItemCardList for rendering item cards
- share BuildList for displaying build options
- update FinalBuildList and AllBuilds to use new components
- add unit tests
- update memory bank and changelog

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_6864ec52c8c8832babbe9c283eb4b47b