### PR TITLE
Add item icons to dropdown lists

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,15 +18,16 @@
 2025-06-12 Display item descriptions without label src/components/ResultsSection.tsx
 2025-06-12 Fix mobile layout issues and disable iOS input zoom src/components
 
-2025-06-14  add tests for dropdown, toolbar, and calculator  src/components
-2025-06-15  add import/export modal for state management  src/components/ImportExportModal.tsx
-2025-06-15  fix import modal usability issues and persist equipped toggle  src/components/ImportExportModal.tsx
-2025-06-28  fix DFS selection logic for build ranking  src/Optimizer.tsx
-2025-06-30  add All Hero and No Hero options for hero selection  src/components/input_view/HeroSelect.tsx
-2025-06-30  add toggle to enable/disable editor overrides  src/components/input_view/OverrideToggle.tsx
-2025-07-01  add selectable build list and hoverable item overview  src/components/results_view
-2025-07-01  create ItemGallery component for browsing items  src/components/ItemGallery.tsx
-2025-07-01  integrate ItemGallery into Optimizer view  src/Optimizer.tsx
-2025-07-01  enhance ItemGallery with search, tooltip preview, folding, scroll  src/components/ItemGallery.tsx
-2025-07-02  move tooltip to redux store  src/slices/tooltipSlice.ts
-2025-07-02  refactor item tables into reusable components  src/components
+2025-06-14 add tests for dropdown, toolbar, and calculator src/components
+2025-06-15 add import/export modal for state management src/components/ImportExportModal.tsx
+2025-06-15 fix import modal usability issues and persist equipped toggle src/components/ImportExportModal.tsx
+2025-06-28 fix DFS selection logic for build ranking src/Optimizer.tsx
+2025-06-30 add All Hero and No Hero options for hero selection src/components/input_view/HeroSelect.tsx
+2025-06-30 add toggle to enable/disable editor overrides src/components/input_view/OverrideToggle.tsx
+2025-07-01 add selectable build list and hoverable item overview src/components/results_view
+2025-07-01 create ItemGallery component for browsing items src/components/ItemGallery.tsx
+2025-07-01 integrate ItemGallery into Optimizer view src/Optimizer.tsx
+2025-07-01 enhance ItemGallery with search, tooltip preview, folding, scroll src/components/ItemGallery.tsx
+2025-07-02 move tooltip to redux store src/slices/tooltipSlice.ts
+2025-07-02 refactor item tables into reusable components src/components
+2025-07-02 show item icons in dropdown lists src/components/shared/SearchableDropdown.tsx

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -11,3 +11,4 @@ Implemented hoverable item overview grid and radio-based build selection in Resu
 
 Moved tooltip state to Redux for global usage.
 Refactored item lists into reusable ItemCardList and BuildList components.
+Added item icons to SearchableDropdown lists for item selections.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -9,3 +9,4 @@
 - Enhanced ItemGallery with search, hover tooltip, fold button, and scrollable grid.
 - Implemented hoverable item overview grid and selectable build list.
 - Refactored item lists into reusable components.
+- Added item icons to dropdown lists using SearchableDropdown.

--- a/my-app/src/components/ItemGallery.tsx
+++ b/my-app/src/components/ItemGallery.tsx
@@ -18,9 +18,7 @@ export default function ItemGallery({ items }: Props) {
   const [search, setSearch] = useState("");
   const dispatch = useAppDispatch();
 
-  const filtered = items.filter((it) =>
-    it.name.toLowerCase().includes(search.toLowerCase()),
-  );
+  const filtered = items.filter((it) => it.name.toLowerCase().includes(search.toLowerCase()));
 
   return (
     <div className="glass-card space-y-6 rounded-xl shadow-lg p-6 sm:p-8  dark:border-gray-700">
@@ -57,9 +55,7 @@ export default function ItemGallery({ items }: Props) {
               {folded ? "Show" : "Hide"}
             </button>
           </div>
-          {editMode && (
-            <div className="mt-1 text-sm text-indigo-500">Edit mode enabled</div>
-          )}
+          {editMode && <div className="mt-1 text-sm text-indigo-500">Edit mode enabled</div>}
         </div>
         {!folded && (
           <>
@@ -71,6 +67,7 @@ export default function ItemGallery({ items }: Props) {
                   value: it.name,
                   label: it.name,
                   color: rarityColor(it.rarity),
+                  iconUrl: it.iconUrl,
                 })),
               ]}
               value={search}
@@ -83,33 +80,19 @@ export default function ItemGallery({ items }: Props) {
                   key={idx}
                   type="button"
                   onClick={() => setSelected(it)}
-                  onMouseEnter={(e) =>
-                    dispatch(
-                      setTooltip({ item: it, x: e.clientX, y: e.clientY }),
-                    )
-                  }
-                  onMouseMove={(e) =>
-                    dispatch(
-                      setTooltip({ item: it, x: e.clientX, y: e.clientY }),
-                    )
-                  }
+                  onMouseEnter={(e) => dispatch(setTooltip({ item: it, x: e.clientX, y: e.clientY }))}
+                  onMouseMove={(e) => dispatch(setTooltip({ item: it, x: e.clientX, y: e.clientY }))}
                   onMouseLeave={() => dispatch(clearTooltip())}
                   className="flex flex-col items-center gap-1 p-2 rounded border dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800"
                 >
                   {it.iconUrl ? (
-                    <img
-                      src={it.iconUrl}
-                      alt=""
-                      className="h-12 w-12 rounded-full object-cover"
-                    />
+                    <img src={it.iconUrl} alt="" className="h-12 w-12 rounded-full object-cover" />
                   ) : (
                     <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gray-200 text-xs text-gray-500">
                       no icon :(
                     </div>
                   )}
-                  <span className="text-sm text-gray-800 dark:text-gray-200">
-                    {it.name}
-                  </span>
+                  <span className="text-sm text-gray-800 dark:text-gray-200">{it.name}</span>
                 </button>
               ))}
             </div>

--- a/my-app/src/components/__tests__/SearchableDropdown.test.tsx
+++ b/my-app/src/components/__tests__/SearchableDropdown.test.tsx
@@ -10,14 +10,18 @@ describe("SearchableDropdown", () => {
     { value: "2", label: "Two" },
   ];
 
+  it("renders icon when provided", () => {
+    const opts = [{ value: "1", label: "One", iconUrl: "icon.png" }];
+    const { getAllByRole, getByRole } = render(
+      <SearchableDropdown label="Icon" options={opts} value="" onChange={() => {}} />,
+    );
+    fireEvent.click(getAllByRole("button")[0]);
+    expect(getByRole("presentation")).toHaveAttribute("src", "icon.png");
+  });
+
   it("focuses search input when opened", () => {
     const { getAllByRole, getByPlaceholderText } = render(
-      <SearchableDropdown
-        label="Test"
-        options={options}
-        value=""
-        onChange={() => { }}
-      />,
+      <SearchableDropdown label="Test" options={options} value="" onChange={() => {}} />,
     );
     fireEvent.click(getAllByRole("button")[0]);
     const input = getByPlaceholderText("Search...");
@@ -27,12 +31,7 @@ describe("SearchableDropdown", () => {
   it("accepts single result with enter key", () => {
     const handleChange = vi.fn();
     const { getAllByRole, getByPlaceholderText } = render(
-      <SearchableDropdown
-        label="Test"
-        options={options}
-        value=""
-        onChange={handleChange}
-      />,
+      <SearchableDropdown label="Test" options={options} value="" onChange={handleChange} />,
     );
     fireEvent.click(getAllByRole("button")[0]);
     const input = getByPlaceholderText("Search...");

--- a/my-app/src/components/input_view/AvoidSection.tsx
+++ b/my-app/src/components/input_view/AvoidSection.tsx
@@ -1,10 +1,6 @@
 import { useState } from "react";
 import { useAppDispatch, useAppSelector } from "../../hooks";
-import {
-  addAvoid,
-  removeAvoid,
-  toggleAvoidEnabled,
-} from "../../slices/inputSlice";
+import { addAvoid, removeAvoid, toggleAvoidEnabled } from "../../slices/inputSlice";
 import type { Item } from "../../types";
 import { sortItemsByRarityAndName } from "../../utils/item";
 import { rarityColor } from "../../utils/utils";
@@ -32,10 +28,7 @@ export default function AvoidSection({ items }: Props) {
           onChange={() => dispatch(toggleAvoidEnabled())}
           className="h-4 w-4 text-teal-600 border-gray-300 rounded focus:ring-teal-500"
         />
-        <label
-          htmlFor="avoid-toggle"
-          className="text-sm dark:text-gray-300 select-none"
-        >
+        <label htmlFor="avoid-toggle" className="text-sm dark:text-gray-300 select-none">
           Enable Avoid Items
         </label>
       </div>
@@ -51,6 +44,7 @@ export default function AvoidSection({ items }: Props) {
                   value: it.id || it.name,
                   label: `${it.name} (${it.cost})`,
                   color: rarityColor(it.rarity),
+                  iconUrl: it.iconUrl,
                 })),
               ]}
               value={selected}
@@ -71,13 +65,7 @@ export default function AvoidSection({ items }: Props) {
             <div className="flex flex-wrap gap-2 mt-2">
               {avoid.map((id) => {
                 const item = items.find((it) => (it.id || it.name) === id);
-                return (
-                  <Chip
-                    key={id}
-                    label={item ? item.name : id}
-                    onRemove={() => dispatch(removeAvoid(id))}
-                  />
-                );
+                return <Chip key={id} label={item ? item.name : id} onRemove={() => dispatch(removeAvoid(id))} />;
               })}
             </div>
           )}

--- a/my-app/src/components/input_view/EquippedSection.tsx
+++ b/my-app/src/components/input_view/EquippedSection.tsx
@@ -1,10 +1,5 @@
 import { useAppDispatch, useAppSelector } from "../../hooks";
-import {
-  addEquippedSlot,
-  removeEquippedSlot,
-  setEquipped,
-  toggleEquippedEnabled,
-} from "../../slices/inputSlice";
+import { addEquippedSlot, removeEquippedSlot, setEquipped, toggleEquippedEnabled } from "../../slices/inputSlice";
 import type { Item } from "../../types";
 import { attributeValueToLabel } from "../../utils/attributeUtils";
 import { sortItemsByRarityAndName } from "../../utils/item";
@@ -31,10 +26,7 @@ export default function EquippedSection({ items }: Props) {
           onChange={() => dispatch(toggleEquippedEnabled())}
           className="h-4 w-4 text-teal-600 border-gray-300 rounded focus:ring-teal-500"
         />
-        <label
-          htmlFor="use-equipped-checkbox"
-          className="text-sm dark:text-gray-300 select-none"
-        >
+        <label htmlFor="use-equipped-checkbox" className="text-sm dark:text-gray-300 select-none">
           Use Equipped Items
         </label>
       </div>
@@ -54,12 +46,11 @@ export default function EquippedSection({ items }: Props) {
                       .map((a) => `${attributeValueToLabel(a.type)}-${a.value}`)
                       .join(", ")}`,
                     color: rarityColor(it.rarity),
+                    iconUrl: it.iconUrl,
                   })),
                 ]}
                 value={id}
-                onChange={(value) =>
-                  dispatch(setEquipped({ index: idx, id: value }))
-                }
+                onChange={(value) => dispatch(setEquipped({ index: idx, id: value }))}
                 className="flex-grow"
               />
               {equipped.length > 1 && (
@@ -86,12 +77,7 @@ export default function EquippedSection({ items }: Props) {
               )}
             </div>
           ))}
-          {equipped.length < 6 && (
-            <SimpleButton
-              text="Add Slot"
-              onClick={() => dispatch(addEquippedSlot())}
-            />
-          )}
+          {equipped.length < 6 && <SimpleButton text="Add Slot" onClick={() => dispatch(addEquippedSlot())} />}
         </div>
       )}
     </div>

--- a/my-app/src/components/shared/SearchableDropdown.tsx
+++ b/my-app/src/components/shared/SearchableDropdown.tsx
@@ -4,6 +4,7 @@ interface DropdownOption {
   value: string;
   label: string;
   color?: string;
+  iconUrl?: string;
 }
 
 interface DropdownProps {
@@ -34,9 +35,7 @@ export default function SearchableDropdown({
   const displayedLabel = selected?.label || placeholder;
   const displayedColor = selected?.color;
 
-  const filteredOptions = options.filter((o) =>
-    o.label.toLowerCase().includes(search.toLowerCase()),
-  );
+  const filteredOptions = options.filter((o) => o.label.toLowerCase().includes(search.toLowerCase()));
 
   const handleSelect = (optionValue: string) => {
     onChange(optionValue);
@@ -46,10 +45,7 @@ export default function SearchableDropdown({
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(event.target as Node)
-      ) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
         setIsOpen(false);
       }
     };
@@ -67,8 +63,7 @@ export default function SearchableDropdown({
   useEffect(() => {
     if (!isOpen || !triggerRef.current) return;
     const triggerRect = triggerRef.current.getBoundingClientRect();
-    const viewportHeight =
-      window.innerHeight || document.documentElement.clientHeight;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
     const estimatedDropdownHeight = viewportHeight * 0.4;
     const spaceBelow = viewportHeight - triggerRect.bottom;
     const spaceAbove = triggerRect.top;
@@ -94,11 +89,7 @@ export default function SearchableDropdown({
           }}
           ref={triggerRef}
         >
-          <span
-            style={{ color: displayedColor || "inherit" }}
-          >
-            {displayedLabel}
-          </span>
+          <span style={{ color: displayedColor || "inherit" }}>{displayedLabel}</span>
         </button>
         <button
           type="button"
@@ -118,19 +109,12 @@ export default function SearchableDropdown({
             stroke="currentColor"
             className="size-4"
           >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="m19.5 8.25-7.5 7.5-7.5-7.5"
-            />
+            <path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
           </svg>
         </button>
       </span>
       {isOpen && (
-        <div
-          role="menu"
-          className={`${dropdownClasses} ${openUpwards ? "bottom-full mb-2" : "top-full mt-2"}`}
-        >
+        <div role="menu" className={`${dropdownClasses} ${openUpwards ? "bottom-full mb-2" : "top-full mt-2"}`}>
           {options.length > 0 ? (
             <div>
               <p className="sticky top-0 bg-white dark:bg-gray-900 px-3 py-2 text-xs uppercase text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700 z-20">
@@ -161,21 +145,18 @@ export default function SearchableDropdown({
                     handleSelect(option.value);
                   }}
                 >
-                  <span style={{ color: option.color || "inherit" }}>
+                  <span className="flex items-center gap-2" style={{ color: option.color || "inherit" }}>
+                    {option.iconUrl && <img src={option.iconUrl} alt="" className="h-4 w-4 rounded" />}
                     {option.label}
                   </span>
                 </a>
               ))}
               {filteredOptions.length === 0 && (
-                <p className="block px-3 py-2 text-sm text-gray-500 dark:text-gray-400">
-                  No matching options
-                </p>
+                <p className="block px-3 py-2 text-sm text-gray-500 dark:text-gray-400">No matching options</p>
               )}
             </div>
           ) : (
-            <p className="block px-3 py-2 text-sm text-gray-500 dark:text-gray-400">
-              No options available
-            </p>
+            <p className="block px-3 py-2 text-sm text-gray-500 dark:text-gray-400">No options available</p>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary
- show item icons in SearchableDropdown options
- support iconUrl property in dropdown options
- pass iconUrl for item selections in Avoid, Equipped, and ItemGallery components
- test SearchableDropdown icon rendering
- document progress and changelog

## Testing
- `npm run test:coverage --silent`

------
https://chatgpt.com/codex/tasks/task_e_68650f3fe334832b98735f1a4f6a2258