### PR TITLE
Show item icons in dropdown

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,7 @@
 2025-07-01  add local override editor with save/delete and viewer  src/components/ItemGallery.tsx
 2025-07-02  move tooltip to redux store  src/slices/tooltipSlice.ts
 2025-07-02  refactor item tables into reusable components  src/components
+2025-07-03  show item icons in dropdown lists  src/components/shared/SearchableDropdown.tsx
 2025-07-02  improve item display and tooltip handling in ItemsOverviewTable src/components/results_view/ItemsOverviewTable.tsx
 2025-07-02  move tooltip to redux store  src/slices/tooltipSlice.ts
 2025-07-02  refactor item tables into reusable components  src/components

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -11,3 +11,4 @@ Added local override editor in ItemGallery with hero dropdown, attribute rows, a
 Implemented hoverable item overview grid and radio-based build selection in Results section.
 Moved tooltip state to Redux for global usage.
 Refactored item lists into reusable ItemCardList and BuildList components.
+Displayed item icons in SearchableDropdown options.

--- a/my-app/src/components/ItemGallery.tsx
+++ b/my-app/src/components/ItemGallery.tsx
@@ -92,6 +92,7 @@ export default function ItemGallery({ items, heroes, attrTypes }: Props) {
                   value: it.name,
                   label: it.name,
                   color: rarityColor(it.rarity),
+                  iconUrl: it.iconUrl,
                 })),
               ]}
               value={search}

--- a/my-app/src/components/__tests__/SearchableDropdown.test.tsx
+++ b/my-app/src/components/__tests__/SearchableDropdown.test.tsx
@@ -40,4 +40,13 @@ describe("SearchableDropdown", () => {
     fireEvent.keyDown(input, { key: "Enter" });
     expect(handleChange).toHaveBeenCalledWith("1");
   });
+
+  it("shows an icon when provided", () => {
+    const opts = [{ value: "1", label: "One", iconUrl: "icon.png" }];
+    const { getAllByRole } = render(
+      <SearchableDropdown label="Test" options={opts} value="" onChange={() => { }} />,
+    );
+    fireEvent.click(getAllByRole("button")[0]);
+    expect(getAllByRole("presentation")[0]).toHaveAttribute("src", "icon.png");
+  });
 });

--- a/my-app/src/components/input_view/AvoidSection.tsx
+++ b/my-app/src/components/input_view/AvoidSection.tsx
@@ -51,6 +51,7 @@ export default function AvoidSection({ items }: Props) {
                   value: it.id || it.name,
                   label: `${it.name} (${it.cost})`,
                   color: rarityColor(it.rarity),
+                  iconUrl: it.iconUrl,
                 })),
               ]}
               value={selected}

--- a/my-app/src/components/input_view/EquippedSection.tsx
+++ b/my-app/src/components/input_view/EquippedSection.tsx
@@ -54,6 +54,7 @@ export default function EquippedSection({ items }: Props) {
                       .map((a) => `${attributeValueToLabel(a.type)}-${a.value}`)
                       .join(", ")}`,
                     color: rarityColor(it.rarity),
+                    iconUrl: it.iconUrl,
                   })),
                 ]}
                 value={id}

--- a/my-app/src/components/shared/SearchableDropdown.tsx
+++ b/my-app/src/components/shared/SearchableDropdown.tsx
@@ -4,6 +4,7 @@ interface DropdownOption {
   value: string;
   label: string;
   color?: string;
+  iconUrl?: string;
 }
 
 interface DropdownProps {
@@ -154,13 +155,16 @@ export default function SearchableDropdown({
                 <a
                   key={option.value}
                   href="#"
-                  className="block px-3 py-2 text-sm font-medium text-gray-900 dark:text-gray-200 transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
+                  className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-900 dark:text-gray-200 transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
                   role="menuitem"
                   onClick={(e) => {
                     e.preventDefault();
                     handleSelect(option.value);
                   }}
                 >
+                  {option.iconUrl && (
+                    <img src={option.iconUrl} alt="" className="size-5" />
+                  )}
                   <span style={{ color: option.color || "inherit" }}>
                     {option.label}
                   </span>

--- a/my-app/src/components/shared/SearchableDropdown.tsx
+++ b/my-app/src/components/shared/SearchableDropdown.tsx
@@ -95,10 +95,26 @@ export default function SearchableDropdown({
           }}
           ref={triggerRef}
         >
-          <span
-            style={{ color: displayedColor || "inherit" }}
-          >
-            {displayedLabel}
+          <span className="flex items-center gap-2">
+            {selected?.iconUrl && (
+              <img src={selected.iconUrl} alt="" className="size-8" />
+            )}
+            <span
+              style={{
+                color: displayedColor || "inherit",
+                display: "-webkit-box",
+                WebkitLineClamp: 3,
+                WebkitBoxOrient: "vertical",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "normal",
+                maxHeight: "4.5em",
+                lineHeight: "1.5em",
+              }}
+              className="break-words"
+            >
+              {displayedLabel}
+            </span>
           </span>
         </button>
         <button
@@ -163,7 +179,7 @@ export default function SearchableDropdown({
                   }}
                 >
                   {option.iconUrl && (
-                    <img src={option.iconUrl} alt="" className="size-5" />
+                    <img src={option.iconUrl} alt="" className="size-8" />
                   )}
                   <span style={{ color: option.color || "inherit" }}>
                     {option.label}


### PR DESCRIPTION
## Summary
- add optional `iconUrl` property for dropdown options
- display item icons for lists of `Item` objects
- test SearchableDropdown item icons
- document change in memory bank and changelog

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68651602a2e4832b832661965973c169