### PR TITLE
Fix dropdown search

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,3 +38,4 @@
 2025-07-02  local overrides reload and UI markers  src
 2025-07-04  fix local overrides view/edit  src/components/ItemGallery.tsx
 2025-07-06  add cheap and premium build buttons  src/components/input_view/SubmitSection.tsx
+2025-07-12  fix equipped dropdown search  src/components

--- a/item-optimizer/src/components/__tests__/SearchableDropdown.test.tsx
+++ b/item-optimizer/src/components/__tests__/SearchableDropdown.test.tsx
@@ -49,4 +49,18 @@ describe("SearchableDropdown", () => {
     fireEvent.click(getAllByRole("button")[0]);
     expect(getAllByRole("presentation")[0]).toHaveAttribute("src", "icon.png");
   });
+
+  it("filters using searchText when provided", () => {
+    const opts = [
+      { value: "1", label: "Alpha Beta", searchText: "alpha" },
+      { value: "2", label: "Gamma" },
+    ];
+    const { getAllByRole, getByPlaceholderText, queryByText } = render(
+      <SearchableDropdown label="Test" options={opts} value="" onChange={() => { }} />,
+    );
+    fireEvent.click(getAllByRole("button")[0]);
+    const input = getByPlaceholderText("Search...");
+    fireEvent.change(input, { target: { value: "Beta" } });
+    expect(queryByText("Alpha Beta")).not.toBeInTheDocument();
+  });
 });

--- a/item-optimizer/src/components/input_view/EquippedSection.tsx
+++ b/item-optimizer/src/components/input_view/EquippedSection.tsx
@@ -55,6 +55,7 @@ export default function EquippedSection({ items }: Props) {
                       .join(", ")}`,
                     color: rarityColor(it.rarity),
                     iconUrl: it.iconUrl,
+                    searchText: it.name,
                   })),
                 ]}
                 value={id}

--- a/item-optimizer/src/components/shared/SearchableDropdown.tsx
+++ b/item-optimizer/src/components/shared/SearchableDropdown.tsx
@@ -5,6 +5,8 @@ interface DropdownOption {
   label: string;
   color?: string;
   iconUrl?: string;
+  /** Optional text used for filtering, defaults to `label` */
+  searchText?: string;
 }
 
 interface DropdownProps {
@@ -35,9 +37,10 @@ export default function SearchableDropdown({
   const displayedLabel = selected?.label || placeholder;
   const displayedColor = selected?.color;
 
-  const filteredOptions = options.filter((o) =>
-    o.label.toLowerCase().includes(search.toLowerCase()),
-  );
+  const filteredOptions = options.filter((o) => {
+    const text = (o.searchText || o.label).toLowerCase();
+    return text.includes(search.toLowerCase());
+  });
 
   const handleSelect = (optionValue: string) => {
     onChange(optionValue);


### PR DESCRIPTION
## Summary
- support custom searchText in SearchableDropdown
- filter by item name in EquippedSection
- cover new filtering logic with test
- update changelog

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_6871f99950a4832ba90875e11109e902