### PR TITLE
Add incremental build mode

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -39,3 +39,4 @@
 2025-07-04  fix local overrides view/edit  src/components/ItemGallery.tsx
 2025-07-06  add cheap and premium build buttons  src/components/input_view/SubmitSection.tsx
 2025-07-13  reduce mobile padding for main layout and cards  src/App.tsx
+2025-07-14  add incremental build calculator  src/Optimizer.tsx

--- a/item-optimizer/src/components/__tests__/InputSection.test.tsx
+++ b/item-optimizer/src/components/__tests__/InputSection.test.tsx
@@ -29,7 +29,7 @@ describe("InputSection", () => {
     );
     fireEvent.submit(container.querySelector("form")!);
     expect(validate).toHaveBeenCalled();
-    expect(onSubmit).toHaveBeenCalledWith(false);
+    expect(onSubmit).toHaveBeenCalledWith("cheapest");
   });
 
   it("does not submit when validate fails", () => {
@@ -64,7 +64,24 @@ describe("InputSection", () => {
       </Provider>,
     );
     fireEvent.click(getByText("Premium Best Build"));
-    expect(onSubmit).toHaveBeenCalledWith(true);
+    expect(onSubmit).toHaveBeenCalledWith("premium");
+  });
+
+  it("handles incremental button", () => {
+    const onSubmit = vi.fn();
+    const { getByText } = render(
+      <Provider store={store}>
+        <InputSection
+          heroes={heroes}
+          attrTypes={attrTypes}
+          filteredItems={items}
+          onSubmit={onSubmit}
+          validate={() => true}
+        />
+      </Provider>,
+    );
+    fireEvent.click(getByText("Incremental Builds"));
+    expect(onSubmit).toHaveBeenCalledWith("incremental");
   });
 
   it("shows special hero options", () => {

--- a/item-optimizer/src/components/input_view/InputSection.tsx
+++ b/item-optimizer/src/components/input_view/InputSection.tsx
@@ -12,7 +12,7 @@ interface Props {
   heroes: string[];
   attrTypes: string[];
   filteredItems: Item[];
-  onSubmit: (preferHighCost: boolean) => void;
+  onSubmit: (mode: "cheapest" | "premium" | "incremental") => void;
   validate: () => boolean;
 }
 
@@ -23,7 +23,7 @@ export default function InputSection({ heroes, attrTypes, filteredItems, onSubmi
       <form
         onSubmit={(e) => {
           e.preventDefault();
-          if (validate()) onSubmit(false);
+          if (validate()) onSubmit("cheapest");
         }}
         className="grid"
       >

--- a/item-optimizer/src/components/input_view/SubmitSection.tsx
+++ b/item-optimizer/src/components/input_view/SubmitSection.tsx
@@ -2,7 +2,7 @@ import { useAppDispatch, useAppSelector } from "../../hooks";
 import { setToBuy } from "../../slices/inputSlice";
 
 interface Props {
-  onSubmit: (preferHighCost: boolean) => void;
+  onSubmit: (mode: "cheapest" | "premium" | "incremental") => void;
   validate: () => boolean;
 }
 
@@ -16,7 +16,7 @@ export default function SubmitSection({ onSubmit, validate }: Props) {
       <button
         type="button"
         onClick={() => {
-          if (validate()) onSubmit(false);
+          if (validate()) onSubmit("cheapest");
         }}
         className="w-full inline-flex items-center justify-center rounded-lg bg-teal-600 dark:bg-teal-700 px-5 py-3 text-white text-base font-medium shadow-lg transition hover:bg-teal-700 dark:hover:bg-teal-800 disabled:bg-gray-400 dark:disabled:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-teal-500 dark:focus:ring-teal-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
         disabled={!validate()}
@@ -26,12 +26,22 @@ export default function SubmitSection({ onSubmit, validate }: Props) {
       <button
         type="button"
         onClick={() => {
-          if (validate()) onSubmit(true);
+          if (validate()) onSubmit("premium");
         }}
         className="w-full inline-flex items-center justify-center rounded-lg bg-indigo-600 dark:bg-indigo-700 px-5 py-3 text-white text-base font-medium shadow-lg transition hover:bg-indigo-700 dark:hover:bg-indigo-800 disabled:bg-gray-400 dark:disabled:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:focus:ring-indigo-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
         disabled={!validate()}
       >
         Premium Best Build
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          if (validate()) onSubmit("incremental");
+        }}
+        className="w-full inline-flex items-center justify-center rounded-lg bg-amber-600 dark:bg-amber-700 px-5 py-3 text-white text-base font-medium shadow-lg transition hover:bg-amber-700 dark:hover:bg-amber-800 disabled:bg-gray-400 dark:disabled:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-amber-500 dark:focus:ring-amber-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+        disabled={!validate()}
+      >
+        Incremental Builds
       </button>
       <div className="mt-4 grid grid-cols-5 gap-2">
         {[2, 3, 4, 5, 6].map((n) => (

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -13,3 +13,4 @@
 - Local overrides now reload via redux flag; gallery shows override markers.
 - Added premium and cheapest build buttons with new parameter to optimizer.
 - Reduced padding on mobile layout for better usability.
+- Added incremental build calculator with upper bound logic.


### PR DESCRIPTION
## Summary
- add incremental build button to run optimizer over cash range
- update input handling to send string mode to Optimizer
- implement incremental build logic with dynamic upper bound
- test InputSection for new incremental option
- document new feature in changelog and memory bank

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_6875a07481b4832b8cf21eea01e49518