### PR TITLE
fix: deduplicate incremental builds

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -40,3 +40,4 @@
 2025-07-06  add cheap and premium build buttons  src/components/input_view/SubmitSection.tsx
 2025-07-13  reduce mobile padding for main layout and cards  src/App.tsx
 2025-07-14  add incremental build calculator  src/Optimizer.tsx
+2025-07-16  remove duplicate incremental builds  src/Optimizer.tsx src/utils/utils.ts

--- a/item-optimizer/src/Optimizer.tsx
+++ b/item-optimizer/src/Optimizer.tsx
@@ -13,7 +13,14 @@ import { ALL_HEROES, NO_HERO } from "./types";
 import { sortAttributes } from "./utils/attributeUtils";
 import { iconUrlForName } from "./utils/item";
 import { loadLocalOverrides } from "./utils/localOverrides";
-import { aggregate, buildBreakdown, collectRelevantAttributes, meetsMinGroups, scoreFromMap } from "./utils/utils";
+import {
+  aggregate,
+  buildBreakdown,
+  collectRelevantAttributes,
+  meetsMinGroups,
+  scoreFromMap,
+  uniqueByItems,
+} from "./utils/utils";
 
 export default function Optimizer() {
   const [data, setData] = useState<Item[]>([]);
@@ -272,13 +279,14 @@ export default function Optimizer() {
         const res = calcForCash(c);
         if (res) list.push(res);
       }
-      if (list.length === 0) {
+      const unique = uniqueByItems(list);
+      if (unique.length === 0) {
         dispatch(setError("Insufficient cash for any purchase"));
         return;
       }
-      setBuilds(list);
-      setBuildIndex(list.length - 1);
-      setResults(list[list.length - 1]);
+      setBuilds(unique);
+      setBuildIndex(unique.length - 1);
+      setResults(unique[unique.length - 1]);
       return;
     }
 

--- a/item-optimizer/src/utils/__tests__/utils.test.ts
+++ b/item-optimizer/src/utils/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import type { Item, MinAttrGroup, WeightRow } from "../../types";
 import { attributeValueToLabel, sortAttributes } from "../attributeUtils";
-import { aggregate, meetsMinGroups, rarityColor, scoreFromMap } from "../utils";
+import { aggregate, meetsMinGroups, rarityColor, scoreFromMap, uniqueByItems } from "../utils";
 
 describe("optimizer utils", () => {
   test("aggregate sums attributes correctly", () => {
@@ -69,6 +69,20 @@ describe("optimizer utils", () => {
     expect(meetsMinGroups(items, groups)).toBe(true);
     groups[0].value = 9;
     expect(meetsMinGroups(items, groups)).toBe(false);
+  });
+
+  test("uniqueByItems removes duplicate item sets", () => {
+    const a: Item = { name: "A", attributes: [], cost: 1, tab: "w", rarity: "common", id: "1" };
+    const b: Item = { name: "B", attributes: [], cost: 1, tab: "w", rarity: "common", id: "2" };
+    const combos = [
+      { items: [a], cost: 1, score: 5 },
+      { items: [a], cost: 1, score: 5 },
+      { items: [b], cost: 1, score: 5 },
+    ];
+    const unique = uniqueByItems(combos);
+    expect(unique).toHaveLength(2);
+    expect(unique[0].items[0].id).toBe("1");
+    expect(unique[1].items[0].id).toBe("2");
   });
 });
 

--- a/item-optimizer/src/utils/utils.ts
+++ b/item-optimizer/src/utils/utils.ts
@@ -97,3 +97,16 @@ export function rankBestCombos<T extends ResultComboBasic>(
   );
   return { best, alternatives };
 }
+
+export function uniqueByItems<T extends { items: Item[] }>(combos: T[]): T[] {
+  const seen = new Set<string>();
+  return combos.filter((c) => {
+    const key = c.items
+      .map((i) => i.id || i.name)
+      .sort()
+      .join(",");
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -14,3 +14,4 @@ Refactored item lists into reusable ItemCardList and BuildList components.
 Displayed item icons in SearchableDropdown options.
 Integrated local override reloads and per-item restore/update buttons.
 Reduced padding on mobile layout to improve usability.
+Deduplicated incremental build results to remove duplicate item combos.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -14,3 +14,4 @@
 - Added premium and cheapest build buttons with new parameter to optimizer.
 - Reduced padding on mobile layout for better usability.
 - Added incremental build calculator with upper bound logic.
+- Deduplicated incremental build results to avoid repeated item combos.


### PR DESCRIPTION
## Summary
- prevent incremental build list from including duplicate item combos
- add utility to filter builds by unique item sets
- document incremental dedupe and update project memory

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2f6a36218832b9de73e7c7ee140e9